### PR TITLE
Fix Escape key matching

### DIFF
--- a/tui/app.go
+++ b/tui/app.go
@@ -343,7 +343,7 @@ func (d *diffViewer) handleKey(key vaxis.Key) (Command, error) {
 		return d.handleCommentNormalKey(key), nil
 	}
 	if d.helpVisible {
-		if keyQuestionMark(key) || key.Matches('q') || key.Matches(vaxis.KeyEsc) || key.MatchString("Esc") {
+		if keyQuestionMark(key) || key.Matches('q') || keyEscape(key) {
 			d.helpVisible = false
 			return CommandRedraw, nil
 		}
@@ -418,7 +418,7 @@ func (d *diffViewer) handleKey(key vaxis.Key) (Command, error) {
 	case key.Matches('c', vaxis.ModCtrl), key.Matches('q'):
 		d.keys.Clear()
 		return CommandNone, nil
-	case key.Matches(vaxis.KeyEsc), key.MatchString("Esc"):
+	case keyEscape(key):
 		if d.mode != modeNormal || d.selection.Active {
 			d.keys.Clear()
 			d.exitVisualMode()
@@ -638,7 +638,7 @@ func (d *diffViewer) handleTextObjectKey(key vaxis.Key) (Command, error) {
 	state := d.textObject
 	d.textObject = textObjectState{}
 
-	if key.Matches(vaxis.KeyEsc) || key.MatchString("Esc") {
+	if keyEscape(key) {
 		return CommandNone, nil
 	}
 
@@ -711,7 +711,7 @@ func statDetail(stat diff.Stat) string {
 
 func (d *diffViewer) handleFuzzyKey(key vaxis.Key) Command {
 	switch {
-	case key.Matches(vaxis.KeyEsc), key.MatchString("Esc"):
+	case keyEscape(key):
 		d.closeFuzzyFinder()
 		return CommandRedraw
 	case key.Matches(vaxis.KeyEnter):
@@ -756,6 +756,10 @@ func (d *diffViewer) acceptFuzzyFinder() Command {
 func (d *diffViewer) closeFuzzyFinder() {
 	d.finder = nil
 	d.mode = modeNormal
+}
+
+func keyEscape(key vaxis.Key) bool {
+	return key.Matches(vaxis.KeyEsc) || key.MatchString("Escape")
 }
 
 func keyQuestionMark(key vaxis.Key) bool {
@@ -4102,7 +4106,7 @@ func (d *diffViewer) openReviewCommentEditorAtIndex(index int) bool {
 func (d *diffViewer) handleCommentKey(key vaxis.Key) Command {
 	command := CommandNone
 	switch {
-	case key.Matches(vaxis.KeyEsc), key.MatchString("Esc"):
+	case keyEscape(key):
 		d.mode = modeNormal
 		return CommandRedraw
 	case key.Matches(vaxis.KeyEnter), key.Keycode == vaxis.KeyEnter:
@@ -4146,7 +4150,7 @@ func (d *diffViewer) handleCommentNormalKey(key vaxis.Key) Command {
 	d.keys.ClearExpired(time.Now())
 	command := CommandNone
 	switch {
-	case key.Matches(vaxis.KeyEsc), key.MatchString("Esc"):
+	case keyEscape(key):
 		if d.commentSelection.Active {
 			d.commentSelection = textSelection{}
 			d.mode = modeNormal
@@ -4493,7 +4497,7 @@ func (d *diffViewer) enterCommandMode() {
 
 func (d *diffViewer) handleCommandKey(key vaxis.Key) Command {
 	switch {
-	case key.Matches(vaxis.KeyEsc), key.MatchString("Esc"):
+	case keyEscape(key):
 		d.commandLine = ""
 		d.mode = modeNormal
 		return CommandRedraw
@@ -4536,7 +4540,7 @@ func (d *diffViewer) clearSearch() bool {
 
 func (d *diffViewer) handleSearchKey(key vaxis.Key) (Command, error) {
 	switch {
-	case key.Matches(vaxis.KeyEsc), key.MatchString("Esc"):
+	case keyEscape(key):
 		d.mode = modeNormal
 		d.clearSearch()
 		return CommandRedraw, nil

--- a/tui/app_test.go
+++ b/tui/app_test.go
@@ -2167,6 +2167,33 @@ func TestDiffViewerCommentEditorShiftBackspaceDeletes(t *testing.T) {
 	}
 }
 
+func TestDiffViewerCommentEditorShiftEInsertsCapitalE(t *testing.T) {
+	viewer := &diffViewer{
+		rows: []diff.Row{{
+			Kind:   diff.RowAdd,
+			Text:   "hello",
+			Code:   "hello",
+			Review: review.Anchor{Path: "main.go", Line: 1, Side: review.SideRight},
+		}},
+	}
+	viewer.Layout(Tight(Size{Width: 40, Height: 10}))
+	openReviewCommentEditor(t, viewer)
+
+	cmd, err := viewer.HandleEvent(vaxis.Key{Text: "E", Keycode: 'e', ShiftedCode: 'E', Modifiers: vaxis.ModShift})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cmd != CommandRedraw {
+		t.Fatalf("command = %v, want %v", cmd, CommandRedraw)
+	}
+	if viewer.mode != modeInsert {
+		t.Fatalf("mode = %v, want insert", viewer.mode)
+	}
+	if got, want := viewer.editor.body(), "E"; got != want {
+		t.Fatalf("editor body = %q, want %q", got, want)
+	}
+}
+
 func TestDiffViewerCommentEditorEscapeLeavesInsertThenClosesAndSaves(t *testing.T) {
 	viewer := &diffViewer{
 		rows: []diff.Row{


### PR DESCRIPTION
## Summary
- Replace broad `MatchString("Esc")` checks with a shared Escape helper using vaxis' `Escape` key name
- Add a regression test that Shift+e inserts capital E in the comment editor

## Test
- `go test ./...`

Fixes #1