### PR TITLE
Fix upward comment focus navigation

### DIFF
--- a/tui/app.go
+++ b/tui/app.go
@@ -4077,6 +4077,10 @@ func (d *diffViewer) openReviewCommentEditor() bool {
 }
 
 func (d *diffViewer) openReviewCommentEditorAtIndex(index int) bool {
+	return d.openReviewCommentEditorAtIndexFromDirection(index, 1)
+}
+
+func (d *diffViewer) openReviewCommentEditorAtIndexFromDirection(index int, direction int) bool {
 	if index < 0 || index >= len(d.reviewDrafts) {
 		return false
 	}
@@ -4088,6 +4092,9 @@ func (d *diffViewer) openReviewCommentEditorAtIndex(index int) bool {
 	}
 	d.editor.row = 0
 	d.editor.col = 0
+	if direction < 0 {
+		d.moveCommentEditorCursorToLastDisplayLineStart()
+	}
 	d.commentSelection = textSelection{}
 	if targetRow := d.commentEditorTargetRow(); targetRow >= 0 {
 		col := 0
@@ -4101,6 +4108,24 @@ func (d *diffViewer) openReviewCommentEditorAtIndex(index int) bool {
 	d.syncCommentEditorScroll()
 	d.ensureCursorVisible()
 	return true
+}
+
+func (d *diffViewer) moveCommentEditorCursorToLastDisplayLineStart() {
+	if d.editor == nil || len(d.editor.lines) == 0 {
+		return
+	}
+	layout, ok := d.commentEditorLayout(d.width, d.height)
+	if ok {
+		lines := d.editor.wrappedLines(layout.inputWidth)
+		if len(lines) > 0 {
+			line := lines[len(lines)-1]
+			d.editor.row = line.line
+			d.editor.col = line.start
+			return
+		}
+	}
+	d.editor.row = len(d.editor.lines) - 1
+	d.editor.col = 0
 }
 
 func (d *diffViewer) handleCommentKey(key vaxis.Key) Command {
@@ -5398,7 +5423,7 @@ func (d *diffViewer) focusAdjacentComment(direction int) bool {
 		if len(indexes) == 0 {
 			return false
 		}
-		return d.openReviewCommentEditorAtIndex(indexes[0])
+		return d.openReviewCommentEditorAtIndexFromDirection(indexes[0], direction)
 	}
 	if row == 0 {
 		return false
@@ -5407,7 +5432,7 @@ func (d *diffViewer) focusAdjacentComment(direction int) bool {
 	if len(indexes) == 0 {
 		return false
 	}
-	return d.openReviewCommentEditorAtIndex(indexes[len(indexes)-1])
+	return d.openReviewCommentEditorAtIndexFromDirection(indexes[len(indexes)-1], direction)
 }
 
 func (d *diffViewer) commentEditorTargetRow() int {

--- a/tui/app_test.go
+++ b/tui/app_test.go
@@ -2275,7 +2275,7 @@ func TestDiffViewerCommentEditorEscapeLeavesInsertThenClosesAndSaves(t *testing.
 	}
 }
 
-func TestDiffViewerFocusAdjacentCommentStartsAtBeginningFromEitherDirection(t *testing.T) {
+func TestDiffViewerFocusAdjacentCommentStartsAtDirectionEdge(t *testing.T) {
 	viewer := &diffViewer{
 		rows: []diff.Row{
 			{
@@ -2328,8 +2328,19 @@ func TestDiffViewerFocusAdjacentCommentStartsAtBeginningFromEitherDirection(t *t
 	if cmd != CommandRedraw || viewer.editor == nil || viewer.mode != modeNormal {
 		t.Fatalf("up command/editor/mode = %v/%v/%v, want focused comment", cmd, viewer.editor != nil, viewer.mode)
 	}
-	if got, want := (selectionPoint{Row: viewer.editor.row, Col: viewer.editor.col}), (selectionPoint{Row: 0, Col: 0}); got != want {
+	if got, want := (selectionPoint{Row: viewer.editor.row, Col: viewer.editor.col}), (selectionPoint{Row: 1, Col: 0}); got != want {
 		t.Fatalf("up editor cursor = %+v, want %+v", got, want)
+	}
+
+	cmd, err = viewer.HandleEvent(vaxis.Key{Text: "k", Keycode: 'k'})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cmd != CommandRedraw {
+		t.Fatalf("move within comment command = %v, want %v", cmd, CommandRedraw)
+	}
+	if got, want := (selectionPoint{Row: viewer.editor.row, Col: viewer.editor.col}), (selectionPoint{Row: 0, Col: 0}); got != want {
+		t.Fatalf("second up editor cursor = %+v, want %+v", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- make focusing an existing comment direction-aware
- entering a comment from below now starts on the last display line so upward navigation moves line-by-line
- update the regression test for directional comment focus

## Test
- go test ./...