### PR TITLE
User config file for keybindings and comment file path

### DIFF
--- a/tui/app.go
+++ b/tui/app.go
@@ -46,15 +46,23 @@ func Run(input string) error {
 		return nil
 	}
 
-	commentFile, err := review.LoadFile(review.DefaultFilePath)
+	cfg := loadConfig()
+
+	commentPath := cfg.CommentFile
+	if commentPath == "" {
+		commentPath = review.DefaultFilePath
+	}
+
+	commentFile, err := review.LoadFile(commentPath)
 	if err != nil {
 		return err
 	}
 	app, err := NewApp(&diffViewer{
 		rows:         rows,
 		reviewDrafts: commentFile.Comments,
-		reviewFile:   review.DefaultFilePath,
+		reviewFile:   commentPath,
 		highlighter:  NewSyntaxHighlighter(),
+		binds:        newBindings(cfg.Keybindings),
 	}, vaxis.Options{
 		CSIuBitMask: keyboardFlags,
 	})
@@ -96,6 +104,7 @@ type diffViewer struct {
 	reviewDirty        bool
 	reviewFile         string
 	editor             *commentEditor
+	binds              Bindings
 	commandLine        string
 	searchQuery        string
 	searchMatches      []searchMatch
@@ -386,7 +395,7 @@ func (d *diffViewer) handleKey(key vaxis.Key) (Command, error) {
 	case key.Matches('e') && d.keys.Pending() == " ":
 		d.keys.Clear()
 		return d.openFileFinderCommand(), nil
-	case key.Matches('/'):
+	case d.binds.Matches(key, "search"):
 		d.keys.Clear()
 		d.enterSearchMode()
 		return CommandRedraw, nil
@@ -394,23 +403,23 @@ func (d *diffViewer) handleKey(key vaxis.Key) (Command, error) {
 		d.keys.Clear()
 		d.enterCommandMode()
 		return CommandRedraw, nil
-	case key.Matches('N'):
+	case d.binds.Matches(key, "prev_result"):
 		d.keys.Clear()
 		if !d.moveSearchMatch(-1) {
 			return CommandNone, nil
 		}
 		return CommandRedraw, nil
-	case key.Matches('s'):
+	case d.binds.Matches(key, "toggle_layout"):
 		d.keys.Clear()
 		d.toggleLayoutMode()
 		return CommandRedraw, nil
-	case key.Matches('n'):
+	case d.binds.Matches(key, "next_result"):
 		d.keys.Clear()
 		if !d.moveSearchMatch(1) {
 			return CommandNone, nil
 		}
 		return CommandRedraw, nil
-	case key.Matches('o'):
+	case d.binds.Matches(key, "open_editor"):
 		d.keys.Clear()
 		if _, ok := d.EditorTarget(); !ok {
 			return CommandRedraw, nil
@@ -461,17 +470,17 @@ func (d *diffViewer) handleKey(key vaxis.Key) (Command, error) {
 		}
 		d.keys.Set("g", time.Now())
 		return CommandNone, nil
-	case key.Matches('G'), key.Matches(vaxis.KeyEnd):
+	case d.binds.Matches(key, "cursor_bottom"):
 		d.keys.Clear()
 		d.cursorBottom()
 		return CommandRedraw, nil
-	case key.Matches('J'):
+	case d.binds.Matches(key, "next_commit"):
 		d.keys.Clear()
 		if !d.jumpCommit(1) {
 			return CommandNone, nil
 		}
 		return CommandRedraw, nil
-	case key.Matches('K'):
+	case d.binds.Matches(key, "prev_commit"):
 		d.keys.Clear()
 		if !d.jumpCommit(-1) {
 			return CommandNone, nil
@@ -484,7 +493,7 @@ func (d *diffViewer) handleKey(key vaxis.Key) (Command, error) {
 		d.keys.Clear()
 		d.cursorTop()
 		return CommandRedraw, nil
-	case key.Matches('d', vaxis.ModCtrl), key.Matches(vaxis.KeyPgDown):
+	case d.binds.Matches(key, "half_page_down"):
 		d.keys.Clear()
 		d.moveCursorRows(d.halfPage())
 		return CommandRedraw, nil
@@ -495,29 +504,29 @@ func (d *diffViewer) handleKey(key vaxis.Key) (Command, error) {
 		}
 		d.keys.Set("d", time.Now())
 		return CommandNone, nil
-	case key.Matches('u', vaxis.ModCtrl), key.Matches(vaxis.KeyPgUp):
+	case d.binds.Matches(key, "half_page_up"):
 		d.keys.Clear()
 		d.moveCursorRows(-d.halfPage())
 		return CommandRedraw, nil
-	case key.Matches('j'), key.Matches(vaxis.KeyDown), key.MatchString("Down"):
+	case d.binds.Matches(key, "cursor_down"):
 		d.keys.Clear()
 		if d.mode == modeNormal && d.focusAdjacentComment(1) {
 			return CommandRedraw, nil
 		}
 		d.moveCursorRows(1)
 		return CommandRedraw, nil
-	case key.Matches('k'), key.Matches(vaxis.KeyUp), key.MatchString("Up"):
+	case d.binds.Matches(key, "cursor_up"):
 		d.keys.Clear()
 		if d.mode == modeNormal && d.focusAdjacentComment(-1) {
 			return CommandRedraw, nil
 		}
 		d.moveCursorRows(-1)
 		return CommandRedraw, nil
-	case key.Matches('l'), key.Matches(vaxis.KeyRight):
+	case d.binds.Matches(key, "cursor_right"):
 		d.keys.Clear()
 		d.moveCursorCols(1)
 		return CommandRedraw, nil
-	case key.Matches('h'), key.Matches(vaxis.KeyLeft):
+	case d.binds.Matches(key, "cursor_left"):
 		d.keys.Clear()
 		d.moveCursorCols(-1)
 		return CommandRedraw, nil
@@ -553,8 +562,7 @@ func (d *diffViewer) handleKey(key vaxis.Key) (Command, error) {
 			return CommandNone, nil
 		}
 		return CommandRedraw, nil
-	case key.Matches('y'), key.Matches(vaxis.KeyCopy),
-		key.Matches('c', vaxis.ModSuper):
+	case d.binds.Matches(key, "yank"):
 		d.keys.Clear()
 		if !d.prepareYank() {
 			return CommandNone, nil
@@ -730,10 +738,10 @@ func (d *diffViewer) handleFuzzyKey(key vaxis.Key) Command {
 		if d.finder.Backspace() {
 			return CommandRedraw
 		}
-	case key.Matches(vaxis.KeyDown), key.Matches('n', vaxis.ModCtrl), key.Matches('j', vaxis.ModCtrl):
+	case d.binds.Matches(key, "fuzzy_next"):
 		d.finder.Move(1)
 		return CommandRedraw
-	case key.Matches(vaxis.KeyUp), key.Matches('p', vaxis.ModCtrl), key.Matches('k', vaxis.ModCtrl):
+	case d.binds.Matches(key, "fuzzy_prev"):
 		d.finder.Move(-1)
 		return CommandRedraw
 	case key.Matches('u', vaxis.ModCtrl):

--- a/tui/config.go
+++ b/tui/config.go
@@ -1,0 +1,97 @@
+package tui
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+
+	"git.sr.ht/~rockorager/vaxis"
+)
+
+// Config holds user configuration loaded from ~/.config/comview/config.json.
+type Config struct {
+	// CommentFile overrides the default path for storing review comments.
+	CommentFile string `json:"comment_file,omitempty"`
+	// Keybindings maps action names to lists of key strings in vaxis
+	// MatchString format (e.g. "ctrl+d", "shift+j", "Page_Down").
+	// A non-empty list replaces the defaults for that action.
+	Keybindings map[string][]string `json:"keybindings,omitempty"`
+}
+
+func loadConfig() Config {
+	data, err := os.ReadFile(configFilePath())
+	if errors.Is(err, os.ErrNotExist) {
+		return Config{}
+	}
+	if err != nil {
+		return Config{}
+	}
+	var cfg Config
+	_ = json.Unmarshal(data, &cfg)
+	return cfg
+}
+
+func configFilePath() string {
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		return filepath.Join(xdg, "comview", "config.json")
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".config", "comview", "config.json")
+}
+
+// defaultKeybindings maps action names to their default key strings.
+// Key strings use vaxis MatchString format: modifier names joined by "+",
+// then the key name or character. Examples: "ctrl+d", "shift+j", "Page_Down".
+var defaultKeybindings = map[string][]string{
+	"cursor_down":    {"j", "Down"},
+	"cursor_up":      {"k", "Up"},
+	"cursor_left":    {"h", "Left"},
+	"cursor_right":   {"l", "Right"},
+	"half_page_down": {"ctrl+d", "Page_Down"},
+	"half_page_up":   {"ctrl+u", "Page_Up"},
+	"cursor_bottom":  {"G", "End"},
+	"next_commit":    {"J"},
+	"prev_commit":    {"K"},
+	"toggle_layout":  {"s"},
+	"search":         {"/"},
+	"next_result":    {"n"},
+	"prev_result":    {"N"},
+	"open_editor":    {"o"},
+	"yank":           {"y", "Copy", "super+c"},
+	// fuzzy finder navigation
+	"fuzzy_next": {"Down", "ctrl+n", "ctrl+j"},
+	"fuzzy_prev": {"Up", "ctrl+p", "ctrl+k"},
+}
+
+// Bindings resolves key events to named actions.
+type Bindings struct {
+	actions map[string][]string
+}
+
+func newBindings(overrides map[string][]string) Bindings {
+	actions := make(map[string][]string, len(defaultKeybindings))
+	for action, keys := range defaultKeybindings {
+		actions[action] = keys
+	}
+	for action, keys := range overrides {
+		if len(keys) > 0 {
+			actions[action] = keys
+		}
+	}
+	return Bindings{actions: actions}
+}
+
+// Matches reports whether key matches any configured key string for action.
+func (b Bindings) Matches(key vaxis.Key, action string) bool {
+	keys := b.actions[action]
+	if keys == nil {
+		keys = defaultKeybindings[action]
+	}
+	for _, s := range keys {
+		if key.MatchString(s) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Adds `~/.config/comview/config.json` (respects `$XDG_CONFIG_HOME`) for user-local settings.

- **`comment_file`** — override the default `.comview/comments.json` path with any absolute path
- **`keybindings`** — remap named actions to custom key strings using vaxis `MatchString` format

### Configurable actions

`cursor_down`, `cursor_up`, `cursor_left`, `cursor_right`, `half_page_down`, `half_page_up`, `cursor_bottom`, `next_commit`, `prev_commit`, `toggle_layout`, `search`, `next_result`, `prev_result`, `open_editor`, `yank`, `fuzzy_next`, `fuzzy_prev`

### Key string format

Uses vaxis `MatchString` format — modifier names joined by `+`, then the key name or character. Examples: `"ctrl+d"`, `"shift+j"`, `"Page_Down"`, `"super+c"`, `"j"`.

A non-empty list in config **replaces** the defaults for that action.

### Example config

```json
{
  "comment_file": "~/.local/share/comview/comments.json",
  "keybindings": {
    "half_page_down": ["ctrl+d", "ctrl+f", "Page_Down"],
    "half_page_up":   ["ctrl+u", "ctrl+b", "Page_Up"],
    "fuzzy_next":     ["Down", "ctrl+n"],
    "fuzzy_prev":     ["Up",   "ctrl+p"]
  }
}
```

### Implementation notes

- Config is loaded once at startup via `loadConfig()` in `tui/config.go`
- `Bindings.Matches` falls back to `defaultKeybindings` when no user config is present, so zero-value `Bindings` works correctly (no init required in tests)
- Existing behavior is fully preserved when no config file exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)