### PR TITLE
Config: soft wrap long diff lines

### DIFF
--- a/tui/app.go
+++ b/tui/app.go
@@ -2017,6 +2017,37 @@ func (d *diffViewer) reviewDraftBoxRowsForSize(docRow int, draft review.CommentD
 	return layout.height
 }
 
+func (d *diffViewer) reviewDraftBoxRowsForViewport(docRow int, draft review.CommentDraft, viewportWidth int) int {
+	layout, ok := d.reviewDraftBoxLayoutForViewport(viewportWidth, docRow, draft)
+	if !ok {
+		return 0
+	}
+	return layout.height
+}
+
+func (d *diffViewer) reviewDraftBoxLayoutForViewport(viewportWidth int, docRow int, draft review.CommentDraft) (reviewDraftBoxLayout, bool) {
+	x := 0
+	if docRow >= 0 && docRow < len(d.rows) {
+		x = d.codeOffset(d.rows[docRow])
+	}
+	x, boxWidth, ok := commentBoxGeometryForViewport(viewportWidth, x)
+	if !ok {
+		return reviewDraftBoxLayout{}, false
+	}
+	bodyWidth := boxWidth - 4
+	if bodyWidth < 1 {
+		return reviewDraftBoxLayout{}, false
+	}
+	lines := commentBodyDisplayLines(draft.Body, bodyWidth)
+	return reviewDraftBoxLayout{
+		x:         x,
+		width:     boxWidth,
+		height:    len(lines) + 2,
+		bodyWidth: bodyWidth,
+		lines:     lines,
+	}, true
+}
+
 func (d *diffViewer) reviewDraftBoxRowsAfterRowForSize(row int, width int, height int) int {
 	rows := 0
 	if d.editor != nil && d.commentEditorTargetRow() == row {
@@ -2027,6 +2058,20 @@ func (d *diffViewer) reviewDraftBoxRowsAfterRowForSize(row int, width int, heigh
 			continue
 		}
 		rows += d.reviewDraftBoxRowsForSize(row, draft, width, height)
+	}
+	return rows
+}
+
+func (d *diffViewer) reviewDraftBoxRowsAfterRowForViewport(row int, viewportWidth int) int {
+	rows := 0
+	if d.editor != nil && d.commentEditorTargetRow() == row {
+		rows += d.commentEditorHeightForViewport(viewportWidth, row)
+	}
+	for _, draft := range d.reviewDraftsEndingAtRow(row) {
+		if d.editor != nil && d.editor.draftIndex >= 0 && d.editor.draftIndex < len(d.reviewDrafts) && d.reviewDrafts[d.editor.draftIndex] == draft {
+			continue
+		}
+		rows += d.reviewDraftBoxRowsForViewport(row, draft, viewportWidth)
 	}
 	return rows
 }
@@ -6371,9 +6416,13 @@ func (d *diffViewer) totalDisplayRowsForSize(width int, height int) int {
 		}
 		return total
 	}
+	return d.totalDisplayRowsForViewport(width, height)
+}
+
+func (d *diffViewer) totalDisplayRowsForViewport(viewportWidth int, height int) int {
 	rows := 0
 	for row := range d.rows {
-		rows += d.rowDisplayHeightForSize(row, width, height)
+		rows += d.rowDisplayHeightForViewport(row, viewportWidth, height)
 	}
 	return rows
 }
@@ -6403,6 +6452,13 @@ func (d *diffViewer) rowDisplayHeightForSize(row int, width int, height int) int
 		return 0
 	}
 	return d.wrappedDocRowHeight(row, width) + d.reviewDraftBoxRowsAfterRowForSize(row, width, height)
+}
+
+func (d *diffViewer) rowDisplayHeightForViewport(row int, viewportWidth int, height int) int {
+	if row < 0 || row >= len(d.rows) {
+		return 0
+	}
+	return d.wrappedDocRowHeight(row, viewportWidth) + d.reviewDraftBoxRowsAfterRowForViewport(row, viewportWidth)
 }
 
 func (d *diffViewer) sideBySideRowDisplayHeightForSize(row sideBySideRow, width int, height int) int {
@@ -6517,6 +6573,25 @@ func (d *diffViewer) commentEditorHeightForSize(width int, height int) int {
 	if !ok {
 		return 0
 	}
+	return d.commentEditorHeightForBoxWidth(boxWidth)
+}
+
+func (d *diffViewer) commentEditorHeightForViewport(viewportWidth int, targetRow int) int {
+	if d.editor == nil || viewportWidth <= 0 || targetRow < 0 {
+		return 0
+	}
+	x := 0
+	if targetRow < len(d.rows) {
+		x = d.codeOffset(d.rows[targetRow])
+	}
+	_, boxWidth, ok := commentBoxGeometryForViewport(viewportWidth, x)
+	if !ok {
+		return 0
+	}
+	return d.commentEditorHeightForBoxWidth(boxWidth)
+}
+
+func (d *diffViewer) commentEditorHeightForBoxWidth(boxWidth int) int {
 	inputWidth := boxWidth - 4
 	if inputWidth < 1 {
 		return 0

--- a/tui/app.go
+++ b/tui/app.go
@@ -946,9 +946,11 @@ func (d *diffViewer) paintStackedRows(win vaxis.Window) {
 		return
 	}
 
+	verticalVisible, _ := d.scrollbarVisibility(d.width, d.height)
+	viewportWidth := horizontalViewportWidth(d.width, verticalVisible)
 	screenRow := -d.scrollOffset
 	for docRow := d.scroll; docRow < len(d.rows) && screenRow < visible; docRow++ {
-		rowHeight := d.printRowWrapped(win, screenRow, docRow, d.rows[docRow], d.codeSegments[docRow], docRow == d.cursor.Row)
+		rowHeight := d.printRowWrapped(win, viewportWidth, screenRow, docRow, d.rows[docRow], d.codeSegments[docRow], docRow == d.cursor.Row)
 		d.paintSelection(win, screenRow, docRow)
 		screenRow += rowHeight
 		if screenRow >= visible {
@@ -1066,10 +1068,19 @@ func (d *diffViewer) screenRowForDocRow(docRow int, width int, height int) int {
 	if docRow < d.scroll {
 		return -1
 	}
+	viewportWidth := width
+	if d.wrapLines {
+		verticalVisible, _ := d.scrollbarVisibility(width, height)
+		viewportWidth = horizontalViewportWidth(width, verticalVisible)
+	}
 	screenRow := -d.scrollOffset
 	for row := d.scroll; row < docRow && row < len(d.rows); row++ {
-		screenRow += d.wrappedDocRowHeight(row, width)
-		screenRow += d.reviewDraftBoxRowsAfterRowForSize(row, width, height)
+		screenRow += d.wrappedDocRowHeight(row, viewportWidth)
+		if d.wrapLines {
+			screenRow += d.reviewDraftBoxRowsAfterRowForViewport(row, viewportWidth)
+		} else {
+			screenRow += d.reviewDraftBoxRowsAfterRowForSize(row, width, height)
+		}
 	}
 	return screenRow
 }
@@ -2514,14 +2525,13 @@ func (d *diffViewer) printRow(win vaxis.Window, row int, docRow int, diffRow dif
 // printRowWrapped paints a potentially wrapped row and returns the number of
 // screen rows consumed. When wrapLines is off it is equivalent to printRow
 // returning 1.
-func (d *diffViewer) printRowWrapped(win vaxis.Window, startRow int, docRow int, diffRow diff.Row, codeSegments []vaxis.Segment, cursorLine bool) int {
+func (d *diffViewer) printRowWrapped(win vaxis.Window, viewportWidth int, startRow int, docRow int, diffRow diff.Row, codeSegments []vaxis.Segment, cursorLine bool) int {
 	d.printRow(win, startRow, docRow, diffRow, codeSegments, cursorLine)
 	if !d.wrapLines || diffRow.Code == "" {
 		return 1
 	}
-	width, _ := win.Size()
 	codeOffset := d.codeOffset(diffRow)
-	avail := width - codeOffset
+	avail := viewportWidth - codeOffset
 	if avail <= 0 {
 		return 1
 	}
@@ -6396,14 +6406,23 @@ func (d *diffViewer) maxScrollForVisibleRows(visible int, width int, height int)
 	if threshold <= 0 {
 		return 0
 	}
+	viewportWidth := width
+	if d.wrapLines && d.layoutMode != layoutSideBySide {
+		verticalVisible, _ := d.scrollbarVisibility(width, height)
+		viewportWidth = horizontalViewportWidth(width, verticalVisible)
+	}
 	maxScroll := 0
 	displayRows := 0
 	for row := range d.rows {
 		if displayRows <= threshold {
 			maxScroll = row
 		}
-		displayRows += d.wrappedDocRowHeight(row, width)
-		displayRows += d.reviewDraftBoxRowsAfterRowForSize(row, width, height)
+		displayRows += d.wrappedDocRowHeight(row, viewportWidth)
+		if d.wrapLines && d.layoutMode != layoutSideBySide {
+			displayRows += d.reviewDraftBoxRowsAfterRowForViewport(row, viewportWidth)
+		} else {
+			displayRows += d.reviewDraftBoxRowsAfterRowForSize(row, width, height)
+		}
 	}
 	return maxScroll
 }
@@ -6416,7 +6435,12 @@ func (d *diffViewer) totalDisplayRowsForSize(width int, height int) int {
 		}
 		return total
 	}
-	return d.totalDisplayRowsForViewport(width, height)
+	viewportWidth := width
+	if d.wrapLines {
+		verticalVisible, _ := d.scrollbarVisibility(width, height)
+		viewportWidth = horizontalViewportWidth(width, verticalVisible)
+	}
+	return d.totalDisplayRowsForViewport(viewportWidth, height)
 }
 
 func (d *diffViewer) totalDisplayRowsForViewport(viewportWidth int, height int) int {
@@ -6450,6 +6474,11 @@ func (d *diffViewer) wrappedDocRowHeight(docRow int, viewportWidth int) int {
 func (d *diffViewer) rowDisplayHeightForSize(row int, width int, height int) int {
 	if row < 0 || row >= len(d.rows) {
 		return 0
+	}
+	if d.wrapLines && d.layoutMode != layoutSideBySide {
+		verticalVisible, _ := d.scrollbarVisibility(width, height)
+		viewportWidth := horizontalViewportWidth(width, verticalVisible)
+		return d.rowDisplayHeightForViewport(row, viewportWidth, height)
 	}
 	return d.wrappedDocRowHeight(row, width) + d.reviewDraftBoxRowsAfterRowForSize(row, width, height)
 }
@@ -6645,8 +6674,14 @@ func (d *diffViewer) scrollbarVisibility(width int, height int) (vertical bool, 
 		return false, false
 	}
 	if d.wrapLines {
-		totalRows := d.totalDisplayRowsForSize(width, height)
-		vertical = totalRows > visibleRowCapacity(height, false)
+		visible := visibleRowCapacity(height, false)
+		totalRows := d.totalDisplayRowsForViewport(width, height)
+		vertical = totalRows > visible
+		if vertical {
+			viewportWidth := horizontalViewportWidth(width, true)
+			totalRows = d.totalDisplayRowsForViewport(viewportWidth, height)
+			vertical = totalRows > visible
+		}
 		return vertical, false
 	}
 	horizontal = d.contentWidth() > d.contentViewportWidthFor(width, false)

--- a/tui/app.go
+++ b/tui/app.go
@@ -72,6 +72,7 @@ func newDiffApp(rows []diff.Row) (*App, *diffViewer, error) {
 		reviewFile:   commentPath,
 		highlighter:  NewSyntaxHighlighter(),
 		binds:        newBindings(cfg.Keybindings),
+		wrapLines:    cfg.Wrap,
 	}
 	app, err := NewApp(viewer, vaxis.Options{
 		CSIuBitMask: keyboardFlags,
@@ -115,6 +116,7 @@ type diffViewer struct {
 	reviewFile         string
 	editor             *commentEditor
 	binds              Bindings
+	wrapLines          bool
 	emptyMessage       string
 	emptyHint          string
 	commandLine        string
@@ -946,9 +948,9 @@ func (d *diffViewer) paintStackedRows(win vaxis.Window) {
 
 	screenRow := -d.scrollOffset
 	for docRow := d.scroll; docRow < len(d.rows) && screenRow < visible; docRow++ {
-		d.printRow(win, screenRow, docRow, d.rows[docRow], d.codeSegments[docRow], docRow == d.cursor.Row)
+		rowHeight := d.printRowWrapped(win, screenRow, docRow, d.rows[docRow], d.codeSegments[docRow], docRow == d.cursor.Row)
 		d.paintSelection(win, screenRow, docRow)
-		screenRow++
+		screenRow += rowHeight
 		if screenRow >= visible {
 			continue
 		}
@@ -1065,7 +1067,7 @@ func (d *diffViewer) screenRowForDocRow(docRow int, width int, height int) int {
 	}
 	screenRow := -d.scrollOffset
 	for row := d.scroll; row < docRow && row < len(d.rows); row++ {
-		screenRow++
+		screenRow += d.wrappedDocRowHeight(row, width)
 		screenRow += d.reviewDraftBoxRowsAfterRowForSize(row, width, height)
 	}
 	return screenRow
@@ -2417,6 +2419,39 @@ func (d *diffViewer) printRow(win vaxis.Window, row int, docRow int, diffRow dif
 	codeSegments = d.reviewSegments(diffRow, codeSegments)
 	codeSegments = d.searchSegments(docRow, diffRow, codeSegments)
 	printCodeSegmentsAtOffset(win, 0, row, d.xScroll, tabWidthForFile(diffRow.FileName), d.rowSegments(codeSegments, cursorLine)...)
+}
+
+// printRowWrapped paints a potentially wrapped row and returns the number of
+// screen rows consumed. When wrapLines is off it is equivalent to printRow
+// returning 1.
+func (d *diffViewer) printRowWrapped(win vaxis.Window, startRow int, docRow int, diffRow diff.Row, codeSegments []vaxis.Segment, cursorLine bool) int {
+	d.printRow(win, startRow, docRow, diffRow, codeSegments, cursorLine)
+	if !d.wrapLines || diffRow.Code == "" {
+		return 1
+	}
+	width, _ := win.Size()
+	codeOffset := d.codeOffset(diffRow)
+	avail := width - codeOffset
+	if avail <= 0 {
+		return 1
+	}
+	codeWidth := textCellWidth(diffRow.Code)
+	if codeWidth <= avail {
+		return 1
+	}
+	nLines := (codeWidth + avail - 1) / avail
+
+	segs := d.reviewSegments(diffRow, codeSegments)
+	segs = d.searchSegments(docRow, diffRow, segs)
+	segs = d.rowSegments(segs, cursorLine)
+
+	for i := 1; i < nLines; i++ {
+		sr := startRow + i
+		d.fillRowBackground(win, sr, diffRow.Kind, cursorLine)
+		d.fillCodeBackground(win, sr, codeOffset, diffRow.Kind, cursorLine)
+		printCodeSegmentsAtOffset(win, codeOffset, sr, avail*i, segs...)
+	}
+	return nLines
 }
 
 func (d *diffViewer) printStructuredRow(win vaxis.Window, row int, docRow int, diffRow diff.Row, cursorLine bool) bool {
@@ -6274,7 +6309,7 @@ func (d *diffViewer) maxScrollForVisibleRows(visible int, width int, height int)
 		if displayRows <= threshold {
 			maxScroll = row
 		}
-		displayRows++
+		displayRows += d.wrappedDocRowHeight(row, width)
 		displayRows += d.reviewDraftBoxRowsAfterRowForSize(row, width, height)
 	}
 	return maxScroll
@@ -6288,18 +6323,38 @@ func (d *diffViewer) totalDisplayRowsForSize(width int, height int) int {
 		}
 		return total
 	}
-	rows := len(d.rows)
+	rows := 0
 	for row := range d.rows {
-		rows += d.reviewDraftBoxRowsAfterRowForSize(row, width, height)
+		rows += d.rowDisplayHeightForSize(row, width, height)
 	}
 	return rows
+}
+
+func (d *diffViewer) wrappedDocRowHeight(docRow int, viewportWidth int) int {
+	if !d.wrapLines || viewportWidth <= 0 || docRow < 0 || docRow >= len(d.rows) {
+		return 1
+	}
+	row := d.rows[docRow]
+	if row.Code == "" {
+		return 1
+	}
+	codeOffset := d.codeOffset(row)
+	avail := viewportWidth - codeOffset
+	if avail <= 0 {
+		return 1
+	}
+	codeWidth := textCellWidth(row.Code)
+	if codeWidth <= avail {
+		return 1
+	}
+	return (codeWidth + avail - 1) / avail
 }
 
 func (d *diffViewer) rowDisplayHeightForSize(row int, width int, height int) int {
 	if row < 0 || row >= len(d.rows) {
 		return 0
 	}
-	return 1 + d.reviewDraftBoxRowsAfterRowForSize(row, width, height)
+	return d.wrappedDocRowHeight(row, width) + d.reviewDraftBoxRowsAfterRowForSize(row, width, height)
 }
 
 func (d *diffViewer) sideBySideRowDisplayHeightForSize(row sideBySideRow, width int, height int) int {
@@ -6466,7 +6521,11 @@ func (d *diffViewer) scrollbarVisibility(width int, height int) (vertical bool, 
 	if width <= 0 || height <= 1 {
 		return false, false
 	}
-
+	if d.wrapLines {
+		totalRows := d.totalDisplayRowsForSize(width, height)
+		vertical = totalRows > visibleRowCapacity(height, false)
+		return vertical, false
+	}
 	horizontal = d.contentWidth() > d.contentViewportWidthFor(width, false)
 	vertical = len(d.rows) > visibleRowCapacity(height, horizontal)
 	if !horizontal && vertical {

--- a/tui/app.go
+++ b/tui/app.go
@@ -2345,6 +2345,9 @@ func (d *diffViewer) screenColumn(row diff.Row, docCol int) int {
 	if docCol < codeOffset {
 		return docCol
 	}
+	if d.wrapLines && d.layoutMode != layoutSideBySide {
+		return docCol
+	}
 	return codeOffset + docCol - codeOffset - d.xScroll
 }
 

--- a/tui/app.go
+++ b/tui/app.go
@@ -2525,7 +2525,7 @@ func (d *diffViewer) printRowWrapped(win vaxis.Window, startRow int, docRow int,
 	if avail <= 0 {
 		return 1
 	}
-	codeWidth := textCellWidth(diffRow.Code)
+	codeWidth := codeCellWidth(diffRow)
 	if codeWidth <= avail {
 		return 1
 	}
@@ -6440,7 +6440,7 @@ func (d *diffViewer) wrappedDocRowHeight(docRow int, viewportWidth int) int {
 	if avail <= 0 {
 		return 1
 	}
-	codeWidth := textCellWidth(row.Code)
+	codeWidth := codeCellWidth(row)
 	if codeWidth <= avail {
 		return 1
 	}

--- a/tui/app.go
+++ b/tui/app.go
@@ -2449,7 +2449,7 @@ func (d *diffViewer) printRowWrapped(win vaxis.Window, startRow int, docRow int,
 		sr := startRow + i
 		d.fillRowBackground(win, sr, diffRow.Kind, cursorLine)
 		d.fillCodeBackground(win, sr, codeOffset, diffRow.Kind, cursorLine)
-		printCodeSegmentsAtOffset(win, codeOffset, sr, avail*i, segs...)
+		printCodeSegmentsAtOffset(win, codeOffset, sr, avail*i, tabWidthForFile(diffRow.FileName), segs...)
 	}
 	return nLines
 }

--- a/tui/app.go
+++ b/tui/app.go
@@ -6673,7 +6673,7 @@ func (d *diffViewer) scrollbarVisibility(width int, height int) (vertical bool, 
 	if width <= 0 || height <= 1 {
 		return false, false
 	}
-	if d.wrapLines {
+	if d.wrapLines && d.layoutMode != layoutSideBySide {
 		visible := visibleRowCapacity(height, false)
 		totalRows := d.totalDisplayRowsForViewport(width, height)
 		vertical = totalRows > visible

--- a/tui/app.go
+++ b/tui/app.go
@@ -1018,17 +1018,18 @@ func (d *diffViewer) cursorScreenPositionForSize(width int, height int) (int, in
 		return 0, 0, false
 	}
 
-	screenRow := d.screenRowForDocRow(d.cursor.Row, width, height)
-	if screenRow < d.topOccludedRows() || screenRow >= d.visibleRowCapacity() || screenRow >= height {
-		return 0, 0, false
-	}
-
 	verticalVisible, _ := d.scrollbarVisibility(width, height)
 	viewportWidth := horizontalViewportWidth(width, verticalVisible)
 	if viewportWidth <= 0 || !d.cursorColumnInViewport(d.rows[d.cursor.Row], viewportWidth) {
 		return 0, 0, false
 	}
-	screenCol := d.screenColumn(d.rows[d.cursor.Row], d.cursor.Col)
+	screenRow, screenCol, ok := d.cursorDisplayPositionForSize(width, height)
+	if !ok {
+		return 0, 0, false
+	}
+	if screenRow < d.topOccludedRows() || screenRow >= d.visibleRowCapacity() || screenRow >= height {
+		return 0, 0, false
+	}
 	if screenCol < 0 || screenCol >= viewportWidth {
 		return 0, 0, false
 	}
@@ -1086,7 +1087,48 @@ func (d *diffViewer) cursorColumnInViewport(row diff.Row, viewportWidth int) boo
 		return false
 	}
 	codeCol := d.cursor.Col - codeOffset
+	if d.wrapLines && d.layoutMode != layoutSideBySide {
+		return codeCol >= 0 && codeCol <= codeCellWidth(row)
+	}
 	return codeCol >= d.xScroll && codeCol < d.xScroll+codeViewportWidth
+}
+
+func (d *diffViewer) cursorDisplayPositionForSize(width int, height int) (int, int, bool) {
+	if d.cursor.Row < d.scroll || d.cursor.Row >= len(d.rows) {
+		return 0, 0, false
+	}
+	row := d.rows[d.cursor.Row]
+	screenRow := d.screenRowForDocRow(d.cursor.Row, width, height)
+	screenCol := d.screenColumn(row, d.cursor.Col)
+	if !d.wrapLines || d.layoutMode == layoutSideBySide {
+		return screenRow, screenCol, true
+	}
+	verticalVisible, _ := d.scrollbarVisibility(width, height)
+	viewportWidth := horizontalViewportWidth(width, verticalVisible)
+	rowOffset, col, ok := d.wrappedCursorOffset(row, viewportWidth)
+	if !ok {
+		return 0, 0, false
+	}
+	return screenRow + rowOffset, col, true
+}
+
+func (d *diffViewer) wrappedCursorOffset(row diff.Row, viewportWidth int) (int, int, bool) {
+	if row.Code == "" || row.Kind == diff.RowHunk {
+		return 0, d.cursor.Col, d.cursor.Col >= 0 && d.cursor.Col < viewportWidth
+	}
+	codeOffset := d.codeOffset(row)
+	if d.cursor.Col < codeOffset {
+		return 0, d.cursor.Col, d.cursor.Col >= 0 && d.cursor.Col < viewportWidth
+	}
+	avail := viewportWidth - codeOffset
+	if avail <= 0 {
+		return 0, 0, false
+	}
+	codeCol := d.cursor.Col - codeOffset
+	if codeCol < 0 || codeCol > codeCellWidth(row) {
+		return 0, 0, false
+	}
+	return codeCol / avail, codeOffset + codeCol%avail, true
 }
 
 func (d *diffViewer) codeOffset(row diff.Row) int {
@@ -6155,7 +6197,10 @@ func (d *diffViewer) ensureCursorDisplayRowVisible(visible int) {
 		return
 	}
 	for {
-		screenRow := d.screenRowForDocRow(d.cursor.Row, d.width, d.height)
+		screenRow, _, ok := d.cursorDisplayPositionForSize(d.width, d.height)
+		if !ok {
+			return
+		}
 		top := d.topOccludedRows()
 		if screenRow >= 0 && screenRow < top {
 			before := d.displayScrollPositionForSize(d.width, d.height)

--- a/tui/app_test.go
+++ b/tui/app_test.go
@@ -3593,6 +3593,33 @@ func TestDiffViewerLineBoundaryKeys(t *testing.T) {
 	}
 }
 
+func TestDiffViewerWrapModeScrollbarHandlesDrafts(t *testing.T) {
+	row := diff.Row{
+		Kind:   diff.RowAdd,
+		Gutter: "    1 + ",
+		Code:   "new",
+		Review: review.Anchor{Path: "main.go", Line: 1, Side: review.SideRight},
+	}
+	viewer := &diffViewer{
+		rows: []diff.Row{row},
+		reviewDrafts: []review.CommentDraft{{
+			Path: "main.go",
+			Line: 1,
+			Side: review.SideRight,
+			Body: strings.Repeat("draft ", 20),
+		}},
+		wrapLines: true,
+	}
+
+	vertical, horizontal := viewer.scrollbarVisibility(24, 5)
+	if horizontal {
+		t.Fatal("horizontal scrollbar visible in wrap mode")
+	}
+	if !vertical {
+		t.Fatal("vertical scrollbar hidden, want visible for wrapped draft rows")
+	}
+}
+
 func TestDiffViewerWrapModePlacesCursorOnContinuationRow(t *testing.T) {
 	row := diff.Row{
 		Kind:   diff.RowAdd,

--- a/tui/app_test.go
+++ b/tui/app_test.go
@@ -3593,6 +3593,21 @@ func TestDiffViewerLineBoundaryKeys(t *testing.T) {
 	}
 }
 
+func TestDiffViewerWrapModeMeasuresRowsWithVerticalScrollbarWidth(t *testing.T) {
+	viewer := &diffViewer{
+		rows: []diff.Row{
+			{Kind: diff.RowAdd, Code: strings.Repeat("x", 10), Text: strings.Repeat("x", 10)},
+			{Kind: diff.RowContext, Code: "y", Text: "y"},
+			{Kind: diff.RowContext, Code: "z", Text: "z"},
+		},
+		wrapLines: true,
+	}
+
+	if got, want := viewer.maxDisplayScrollForSize(10, 3), 2; got != want {
+		t.Fatalf("max display scroll = %d, want %d", got, want)
+	}
+}
+
 func TestDiffViewerWrappedRowHeightUsesFileTabWidth(t *testing.T) {
 	row := diff.Row{
 		Kind:     diff.RowAdd,

--- a/tui/app_test.go
+++ b/tui/app_test.go
@@ -3593,6 +3593,25 @@ func TestDiffViewerLineBoundaryKeys(t *testing.T) {
 	}
 }
 
+func TestDiffViewerWrapModeIgnoresStaleHorizontalScrollForScreenColumns(t *testing.T) {
+	row := diff.Row{
+		Kind:   diff.RowAdd,
+		Gutter: "    1 + ",
+		Code:   strings.Repeat("x", 40),
+	}
+	viewer := &diffViewer{
+		rows:      []diff.Row{row},
+		wrapLines: true,
+		xScroll:   6,
+	}
+
+	got := viewer.screenColumn(row, testCodeOffset(row)+3)
+	want := testCodeOffset(row) + 3
+	if got != want {
+		t.Fatalf("screen column = %d, want %d", got, want)
+	}
+}
+
 func TestDiffViewerSideBySideHorizontalNavigationUsesPaneWidth(t *testing.T) {
 	row := diff.Row{
 		Kind:   diff.RowAdd,

--- a/tui/app_test.go
+++ b/tui/app_test.go
@@ -3741,6 +3741,27 @@ func TestDiffViewerSideBySideHorizontalNavigationUsesPaneWidth(t *testing.T) {
 	}
 }
 
+func TestDiffViewerWrapModeDoesNotHideSideBySideHorizontalScrollbar(t *testing.T) {
+	row := diff.Row{
+		Kind:   diff.RowAdd,
+		Gutter: "    1 + ",
+		Code:   strings.Repeat("x", 60),
+	}
+	row.Text = row.Gutter + row.Code
+	viewer := &diffViewer{
+		rows:       []diff.Row{row},
+		layoutMode: layoutSideBySide,
+		wrapLines:  true,
+	}
+	viewer.Layout(Tight(Size{Width: 80, Height: 10}))
+
+	bar := viewer.horizontalScrollbar(80, 10)
+
+	if !bar.Visible {
+		t.Fatal("horizontal scrollbar hidden, want side-by-side overflow unaffected by wrap mode")
+	}
+}
+
 func TestDiffViewerSideBySideHorizontalScrollbarUsesPaneWidth(t *testing.T) {
 	row := diff.Row{
 		Kind:   diff.RowAdd,

--- a/tui/app_test.go
+++ b/tui/app_test.go
@@ -3593,6 +3593,52 @@ func TestDiffViewerLineBoundaryKeys(t *testing.T) {
 	}
 }
 
+func TestDiffViewerWrapModePlacesCursorOnContinuationRow(t *testing.T) {
+	row := diff.Row{
+		Kind:   diff.RowAdd,
+		Gutter: "    1 + ",
+		Code:   strings.Repeat("x", 30),
+	}
+	viewer := &diffViewer{
+		rows:      []diff.Row{row},
+		cursor:    selectionPoint{Row: 0, Col: testCodeOffset(row) + 14},
+		wrapLines: true,
+	}
+	viewer.Layout(Tight(Size{Width: 20, Height: 10}))
+
+	col, rowNum, ok := viewer.cursorScreenPositionForSize(20, 10)
+	if !ok {
+		t.Fatal("cursor position not found")
+	}
+	if got, want := rowNum, 1; got != want {
+		t.Fatalf("cursor screen row = %d, want %d", got, want)
+	}
+	if got, want := col, testCodeOffset(row)+2; got != want {
+		t.Fatalf("cursor screen col = %d, want %d", got, want)
+	}
+}
+
+func TestDiffViewerWrapModeScrollsCursorContinuationRowIntoView(t *testing.T) {
+	row := diff.Row{
+		Kind:   diff.RowAdd,
+		Gutter: "    1 + ",
+		Code:   strings.Repeat("x", 40),
+	}
+	viewer := &diffViewer{
+		rows:      []diff.Row{row},
+		cursor:    selectionPoint{Row: 0, Col: testCodeOffset(row) + 30},
+		wrapLines: true,
+	}
+	viewer.Layout(Tight(Size{Width: 20, Height: 3}))
+
+	viewer.ensureCursorRowVisible()
+
+	_, _, ok := viewer.cursorScreenPositionForSize(20, 3)
+	if !ok {
+		t.Fatal("cursor continuation row was not scrolled into view")
+	}
+}
+
 func TestDiffViewerWrapModeIgnoresStaleHorizontalScrollForScreenColumns(t *testing.T) {
 	row := diff.Row{
 		Kind:   diff.RowAdd,

--- a/tui/app_test.go
+++ b/tui/app_test.go
@@ -3593,6 +3593,22 @@ func TestDiffViewerLineBoundaryKeys(t *testing.T) {
 	}
 }
 
+func TestDiffViewerWrappedRowHeightUsesFileTabWidth(t *testing.T) {
+	row := diff.Row{
+		Kind:     diff.RowAdd,
+		FileName: "main.py",
+		Code:     "\t123456",
+	}
+	viewer := &diffViewer{
+		rows:      []diff.Row{row},
+		wrapLines: true,
+	}
+
+	if got, want := viewer.wrappedDocRowHeight(0, 10), 1; got != want {
+		t.Fatalf("wrapped row height = %d, want %d", got, want)
+	}
+}
+
 func TestDiffViewerWrapModeScrollbarHandlesDrafts(t *testing.T) {
 	row := diff.Row{
 		Kind:   diff.RowAdd,

--- a/tui/config.go
+++ b/tui/config.go
@@ -13,6 +13,8 @@ import (
 type Config struct {
 	// CommentFile overrides the default path for storing review comments.
 	CommentFile string `json:"comment_file,omitempty"`
+	// Wrap enables soft-wrapping of long diff lines instead of horizontal scrolling.
+	Wrap bool `json:"wrap,omitempty"`
 	// Keybindings maps action names to lists of key strings in vaxis
 	// MatchString format (e.g. "ctrl+d", "shift+j", "Page_Down").
 	// A non-empty list replaces the defaults for that action.


### PR DESCRIPTION
## Summary

Adds opt-in soft wrapping of long diff lines via `"wrap": true` in `~/.config/comview/config.json` (builds on #7).

- Long lines fold at the terminal edge instead of requiring horizontal scroll
- Horizontal scrollbar is hidden in wrap mode
- Scroll, cursor visibility, and `maxScroll` accounting are all wrap-aware
- Side-by-side mode is unaffected

### How it works

- `wrappedDocRowHeight(docRow, viewportWidth)` computes screen rows needed per doc row
- `printRowWrapped` paints the gutter + first chunk on the first screen row, then continuation chunks on subsequent rows with background fill
- `rowDisplayHeightForSize`, `screenRowForDocRow`, `totalDisplayRowsForSize`, and `maxScrollForVisibleRows` all use wrapped heights so scrolling stays accurate
- `scrollbarVisibility` suppresses the horizontal scrollbar and uses total wrapped row count for the vertical scrollbar

### Example config

```json
{
  "wrap": true
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)