### PR TITLE
Resolve diff paths from worktree root

### DIFF
--- a/tui/git.go
+++ b/tui/git.go
@@ -1,0 +1,14 @@
+package tui
+
+import (
+	"os/exec"
+	"strings"
+)
+
+func gitWorkTreeRoot() string {
+	output, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(output))
+}

--- a/tui/ui_diff_run.go
+++ b/tui/ui_diff_run.go
@@ -17,11 +17,13 @@ func runUIDiff(rows []diff.Row) error {
 	if err != nil {
 		return err
 	}
+	root := uiDiffRootWithReviewFileAndBindings(rows, cfg.Wrap, commentFile.Comments, commentPath, true, newBindings(cfg.Keybindings)).(uiDiffView)
+	root.WorkTreeRoot = gitWorkTreeRoot()
 	if cfg.Theme != "" {
 		if t, ok := ThemeByName(cfg.Theme); ok {
 			theme := uiThemeFromBaseColors(t.Colors)
-			return vui.Run(uiDiffRootWithReviewFileAndBindings(rows, cfg.Wrap, commentFile.Comments, commentPath, true, newBindings(cfg.Keybindings)), vui.WithTheme(theme))
+			return vui.Run(root, vui.WithTheme(theme))
 		}
 	}
-	return vui.Run(uiDiffRootWithReviewFileAndBindings(rows, cfg.Wrap, commentFile.Comments, commentPath, true, newBindings(cfg.Keybindings)))
+	return vui.Run(root)
 }

--- a/tui/ui_diff_viewer.go
+++ b/tui/ui_diff_viewer.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -20,6 +21,7 @@ type uiDiffView struct {
 	Wrap          bool
 	ReviewDrafts  []review.CommentDraft
 	ReviewFile    string
+	WorkTreeRoot  string
 	ShowStatus    bool
 	Binds         Bindings
 	EmptyMessage  string
@@ -2161,6 +2163,7 @@ func (s *uiDiffViewState) editorTarget() (EditorTarget, bool) {
 		s.setStatusMessage("No file.")
 		return EditorTarget{}, false
 	}
+	target.Path = editorPathInRoot(target.Path, w.WorkTreeRoot)
 	return target, true
 }
 
@@ -2181,6 +2184,13 @@ func uiDiffEditorTarget(rows []diff.Row, cursor selectionPoint) (EditorTarget, b
 		column = editorColumnAtCell(row.Code, cursor.Col, tabWidthForFile(row.FileName))
 	}
 	return EditorTarget{Path: row.FileName, Line: line, Column: column}, true
+}
+
+func editorPathInRoot(path string, root string) string {
+	if path == "" || root == "" || filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Join(root, path)
 }
 
 func (s *uiDiffViewState) deleteReviewDraftCommand(rows []diff.Row, base []review.CommentDraft) {

--- a/tui/ui_diff_viewer_test.go
+++ b/tui/ui_diff_viewer_test.go
@@ -1484,6 +1484,20 @@ func TestUIDiffViewEditorTargetFallsBackToLineOne(t *testing.T) {
 	}
 }
 
+func TestEditorPathInRootUsesWorktreeRootForRelativePaths(t *testing.T) {
+	root := t.TempDir()
+	if got, want := editorPathInRoot("sub/main.go", root), filepath.Join(root, "sub/main.go"); got != want {
+		t.Fatalf("path = %q, want %q", got, want)
+	}
+}
+
+func TestEditorPathInRootLeavesAbsolutePathsAlone(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "main.go")
+	if got := editorPathInRoot(path, t.TempDir()); got != path {
+		t.Fatalf("path = %q, want %q", got, path)
+	}
+}
+
 func TestUIDiffViewOReportsMissingFile(t *testing.T) {
 	app := newUIDiffTestAppWithBaseDraftsAndStatus([]diff.Row{{Kind: diff.RowBlank}}, DefaultBaseColors(), false, nil, true)
 	size := vui.Size{Width: 40, Height: 3}

--- a/tui/watch.go
+++ b/tui/watch.go
@@ -29,10 +29,11 @@ func RunWatch(command []string) error {
 }
 
 type uiWatchView struct {
-	Command []string
-	Config  Config
-	Review  review.CommentFile
-	File    string
+	Command      []string
+	Config       Config
+	Review       review.CommentFile
+	File         string
+	WorkTreeRoot string
 }
 
 func (w uiWatchView) CreateState() vui.State {
@@ -61,6 +62,7 @@ func (s *uiWatchViewState) Build(ctx vui.BuildContext) vui.Widget {
 
 func (s *uiWatchViewState) diffRoot(w uiWatchView) uiDiffView {
 	root := uiDiffRootWithReviewFileAndBindings(s.rows, w.Config.Wrap, w.Review.Comments, w.File, true, newBindings(w.Config.Keybindings)).(uiDiffView)
+	root.WorkTreeRoot = w.WorkTreeRoot
 	root.EmptyMessage = "No changes."
 	root.EmptyHint = fmt.Sprintf("Watching: %s", strings.Join(w.Command, " "))
 	root.InitialStatus = s.message
@@ -120,7 +122,7 @@ func runUIWatch(command []string) error {
 	if err != nil {
 		return err
 	}
-	root := uiWatchView{Command: command, Config: cfg, Review: commentFile, File: commentPath}
+	root := uiWatchView{Command: command, Config: cfg, Review: commentFile, File: commentPath, WorkTreeRoot: gitWorkTreeRoot()}
 	if cfg.Theme != "" {
 		if t, ok := ThemeByName(cfg.Theme); ok {
 			return vui.Run(root, vui.WithTheme(uiThemeFromBaseColors(t.Colors)))


### PR DESCRIPTION
## Summary
- detect the git worktree root for diff and watch modes
- resolve editor target paths relative to the worktree root
- keep absolute editor paths unchanged

Fixes #14

## Tests
- go test ./...