### PR TITLE
tui: Detect light themes from base colors

### DIFF
--- a/tui/ui_diff_viewer.go
+++ b/tui/ui_diff_viewer.go
@@ -44,16 +44,26 @@ func uiDiffRootWithReviewFileAndBindings(rows []diff.Row, wrap bool, drafts []re
 }
 
 func uiThemeFromBaseColors(base BaseColors) vui.Theme {
+	// vaxis palette generation expects the neutral endpoints in dark-to-light
+	// order, even when the selected theme has a light background.
+	mode := vui.DarkTheme
+	black := base.Background
+	white := base.Foreground
+	if relativeLuminance(base.Background) > relativeLuminance(base.Foreground) {
+		mode = vui.LightTheme
+		black = base.Foreground
+		white = base.Background
+	}
 	return vui.ThemeFromPalette(vui.PaletteFromBaseColors(vui.BaseColors{
-		Black:   base.Background,
+		Black:   black,
 		Red:     base.Red,
 		Green:   base.Green,
 		Yellow:  base.Yellow,
 		Blue:    base.Blue,
 		Magenta: base.Magenta,
 		Cyan:    base.Cyan,
-		White:   base.Foreground,
-	}), vui.DarkTheme)
+		White:   white,
+	}), mode)
 }
 
 func (w uiDiffView) CreateState() vui.State {

--- a/tui/ui_diff_viewer_test.go
+++ b/tui/ui_diff_viewer_test.go
@@ -1573,6 +1573,25 @@ func TestUIDiffViewDerivesDiffColorsFromUITheme(t *testing.T) {
 	}
 }
 
+func TestUIThemeFromBaseColorsUsesLightModeForLightBackground(t *testing.T) {
+	themeConfig, ok := ThemeByName("Catppuccin Latte")
+	if !ok {
+		t.Fatal("Catppuccin Latte theme not found")
+	}
+	base := themeConfig.Colors
+	theme := uiThemeFromBaseColors(base)
+
+	if got := theme.Mode; got != vui.LightTheme {
+		t.Fatalf("theme mode = %v, want light", got)
+	}
+	if got := theme.Background; got != base.Background {
+		t.Fatalf("theme background = %v, want %v", got, base.Background)
+	}
+	if got := theme.Foreground; got != base.Foreground {
+		t.Fatalf("theme foreground = %v, want %v", got, base.Foreground)
+	}
+}
+
 func TestUIDiffViewHighlightsCodeWithChroma(t *testing.T) {
 	theme := uiDiffTestTheme()
 	rows := []diff.Row{{Kind: diff.RowAdd, Gutter: "    1 + ", Code: "package main", FileName: "main.go"}}


### PR DESCRIPTION
Problem

Named comview themes were always converted to a dark vaxis theme, even when the selected theme used a light background. That made light theme users see dark-mode dimming and changed-line backgrounds on a light terminal background.

Reproduction

1. Configure comview to use a light named theme:

       {"theme":"Catppuccin Latte"}

2. Use a terminal profile with a light background.
3. Open comview on a diff with a removed line, e.g.:

       diff --git a/example.go b/example.go
       index 1111111..2222222 100644
       --- a/example.go
       +++ b/example.go
       @@ -1,5 +1,6 @@
        package main

        func main() {
       -	println("dim")
       +	println("readable")
       +	println("latte")
        }

4. Experience distress

    <img width="920" height="520" alt="image" src="https://github.com/user-attachments/assets/7d3f1383-50da-4537-9472-28986aa0426a" />


Solution

Derive the vaxis theme mode from the configured foreground and background luminance.
When the background is lighter than the foreground, pass the neutral endpoints to vaxis in dark-to-light order and build a light theme.

<img width="920" height="520" alt="image" src="https://github.com/user-attachments/assets/c0b7e538-0379-4039-bb72-2ebdff93d96e" />
