### PR TITLE
Add shared comment index for review comments

### DIFF
--- a/tui/comment_index.go
+++ b/tui/comment_index.go
@@ -2,7 +2,6 @@ package tui
 
 import (
 	"sort"
-	"strings"
 
 	"go.rockorager.dev/comview/diff"
 	"go.rockorager.dev/comview/review"
@@ -15,9 +14,8 @@ type commentIndex struct {
 
 // commentIndexEntry keeps the original draft plus its resolved visible target row.
 type commentIndexEntry struct {
-	draft  review.CommentDraft
-	row    int
-	anchor review.Anchor
+	draft review.CommentDraft
+	row   int
 }
 
 // buildCommentIndex indexes drafts that resolve against the current visible rows.
@@ -30,9 +28,8 @@ func buildCommentIndex(rows []diff.Row, drafts []review.CommentDraft) commentInd
 			continue
 		}
 		entries = append(entries, commentIndexEntry{
-			draft:  draft,
-			row:    row,
-			anchor: rows[row].Review,
+			draft: draft,
+			row:   row,
 		})
 	}
 	return commentIndex{entries: entries}
@@ -78,14 +75,4 @@ func (idx commentIndex) targetRows() []int {
 	}
 	sort.Ints(targets)
 	return targets
-}
-
-func commentPreview(body string) string {
-	for _, line := range strings.Split(body, "\n") {
-		line = strings.Join(strings.Fields(line), " ")
-		if line != "" {
-			return line
-		}
-	}
-	return ""
 }

--- a/tui/comment_index.go
+++ b/tui/comment_index.go
@@ -1,0 +1,114 @@
+package tui
+
+import (
+	"sort"
+	"strings"
+
+	"go.rockorager.dev/comview/diff"
+	"go.rockorager.dev/comview/review"
+)
+
+type commentIndex struct {
+	entries []commentIndexEntry
+}
+
+type commentIndexEntry struct {
+	Draft     review.CommentDraft
+	Row       int
+	Anchor    review.Anchor
+	Path      string
+	Side      review.Side
+	Line      int
+	StartLine int
+	StartSide review.Side
+	Preview   string
+}
+
+func buildCommentIndex(rows []diff.Row, drafts []review.CommentDraft) commentIndex {
+	entries := make([]commentIndexEntry, 0, len(drafts))
+	for _, draft := range drafts {
+		row, ok := commentIndexTargetRow(rows, draft)
+		if !ok {
+			continue
+		}
+		anchor := rows[row].Review
+		entries = append(entries, commentIndexEntry{
+			Draft:     draft,
+			Row:       row,
+			Anchor:    anchor,
+			Path:      draft.Path,
+			Side:      draft.Side,
+			Line:      draft.Line,
+			StartLine: draft.StartLine,
+			StartSide: draft.StartSide,
+			Preview:   commentPreview(draft.Body),
+		})
+	}
+	return commentIndex{entries: entries}
+}
+
+func commentIndexTargetRow(rows []diff.Row, draft review.CommentDraft) (int, bool) {
+	for rowIndex, row := range rows {
+		if reviewDraftEndsAt(draft, row.Review) {
+			return rowIndex, true
+		}
+	}
+	for rowIndex, row := range rows {
+		if reviewDraftContains(draft, row.Review) {
+			return rowIndex, true
+		}
+	}
+	return 0, false
+}
+
+func (idx commentIndex) Entries() []commentIndexEntry {
+	entries := make([]commentIndexEntry, len(idx.entries))
+	copy(entries, idx.entries)
+	return entries
+}
+
+func (idx commentIndex) EntriesForRow(row int) []commentIndexEntry {
+	entries := make([]commentIndexEntry, 0, 1)
+	for _, entry := range idx.entries {
+		if entry.Row == row {
+			entries = append(entries, entry)
+		}
+	}
+	return entries
+}
+
+func (idx commentIndex) DraftsForRow(row int) []review.CommentDraft {
+	entries := idx.EntriesForRow(row)
+	if len(entries) == 0 {
+		return nil
+	}
+	drafts := make([]review.CommentDraft, 0, len(entries))
+	for _, entry := range entries {
+		drafts = append(drafts, entry.Draft)
+	}
+	return drafts
+}
+
+func (idx commentIndex) TargetRows() []int {
+	seen := make(map[int]bool, len(idx.entries))
+	targets := make([]int, 0, len(idx.entries))
+	for _, entry := range idx.entries {
+		if seen[entry.Row] {
+			continue
+		}
+		seen[entry.Row] = true
+		targets = append(targets, entry.Row)
+	}
+	sort.Ints(targets)
+	return targets
+}
+
+func commentPreview(body string) string {
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.Join(strings.Fields(line), " ")
+		if line != "" {
+			return line
+		}
+	}
+	return ""
+}

--- a/tui/comment_index.go
+++ b/tui/comment_index.go
@@ -8,10 +8,12 @@ import (
 	"go.rockorager.dev/comview/review"
 )
 
+// commentIndex maps visible draft comments to the diff rows that should render or jump to them.
 type commentIndex struct {
 	entries []commentIndexEntry
 }
 
+// commentIndexEntry keeps the original draft plus its resolved visible target row.
 type commentIndexEntry struct {
 	Draft     review.CommentDraft
 	Row       int
@@ -24,6 +26,8 @@ type commentIndexEntry struct {
 	Preview   string
 }
 
+// buildCommentIndex indexes drafts that resolve against the current visible rows.
+// Drafts with no visible matching anchor are skipped.
 func buildCommentIndex(rows []diff.Row, drafts []review.CommentDraft) commentIndex {
 	entries := make([]commentIndexEntry, 0, len(drafts))
 	for _, draft := range drafts {
@@ -47,6 +51,7 @@ func buildCommentIndex(rows []diff.Row, drafts []review.CommentDraft) commentInd
 	return commentIndex{entries: entries}
 }
 
+// commentIndexTargetRow prefers an exact end-anchor match, then any row contained in the draft range.
 func commentIndexTargetRow(rows []diff.Row, draft review.CommentDraft) (int, bool) {
 	for rowIndex, row := range rows {
 		if reviewDraftEndsAt(draft, row.Review) {
@@ -61,6 +66,7 @@ func commentIndexTargetRow(rows []diff.Row, draft review.CommentDraft) (int, boo
 	return 0, false
 }
 
+// Entries returns a copy so callers cannot mutate the shared index.
 func (idx commentIndex) Entries() []commentIndexEntry {
 	entries := make([]commentIndexEntry, len(idx.entries))
 	copy(entries, idx.entries)

--- a/tui/comment_index.go
+++ b/tui/comment_index.go
@@ -66,14 +66,7 @@ func commentIndexTargetRow(rows []diff.Row, draft review.CommentDraft) (int, boo
 	return 0, false
 }
 
-// Entries returns a copy so callers cannot mutate the shared index.
-func (idx commentIndex) Entries() []commentIndexEntry {
-	entries := make([]commentIndexEntry, len(idx.entries))
-	copy(entries, idx.entries)
-	return entries
-}
-
-func (idx commentIndex) EntriesForRow(row int) []commentIndexEntry {
+func (idx commentIndex) entriesForRow(row int) []commentIndexEntry {
 	entries := make([]commentIndexEntry, 0, 1)
 	for _, entry := range idx.entries {
 		if entry.Row == row {
@@ -83,8 +76,8 @@ func (idx commentIndex) EntriesForRow(row int) []commentIndexEntry {
 	return entries
 }
 
-func (idx commentIndex) DraftsForRow(row int) []review.CommentDraft {
-	entries := idx.EntriesForRow(row)
+func (idx commentIndex) draftsForRow(row int) []review.CommentDraft {
+	entries := idx.entriesForRow(row)
 	if len(entries) == 0 {
 		return nil
 	}
@@ -95,7 +88,7 @@ func (idx commentIndex) DraftsForRow(row int) []review.CommentDraft {
 	return drafts
 }
 
-func (idx commentIndex) TargetRows() []int {
+func (idx commentIndex) targetRows() []int {
 	seen := make(map[int]bool, len(idx.entries))
 	targets := make([]int, 0, len(idx.entries))
 	for _, entry := range idx.entries {

--- a/tui/comment_index.go
+++ b/tui/comment_index.go
@@ -15,15 +15,9 @@ type commentIndex struct {
 
 // commentIndexEntry keeps the original draft plus its resolved visible target row.
 type commentIndexEntry struct {
-	Draft     review.CommentDraft
-	Row       int
-	Anchor    review.Anchor
-	Path      string
-	Side      review.Side
-	Line      int
-	StartLine int
-	StartSide review.Side
-	Preview   string
+	draft  review.CommentDraft
+	row    int
+	anchor review.Anchor
 }
 
 // buildCommentIndex indexes drafts that resolve against the current visible rows.
@@ -35,17 +29,10 @@ func buildCommentIndex(rows []diff.Row, drafts []review.CommentDraft) commentInd
 		if !ok {
 			continue
 		}
-		anchor := rows[row].Review
 		entries = append(entries, commentIndexEntry{
-			Draft:     draft,
-			Row:       row,
-			Anchor:    anchor,
-			Path:      draft.Path,
-			Side:      draft.Side,
-			Line:      draft.Line,
-			StartLine: draft.StartLine,
-			StartSide: draft.StartSide,
-			Preview:   commentPreview(draft.Body),
+			draft:  draft,
+			row:    row,
+			anchor: rows[row].Review,
 		})
 	}
 	return commentIndex{entries: entries}
@@ -66,24 +53,15 @@ func commentIndexTargetRow(rows []diff.Row, draft review.CommentDraft) (int, boo
 	return 0, false
 }
 
-func (idx commentIndex) entriesForRow(row int) []commentIndexEntry {
-	entries := make([]commentIndexEntry, 0, 1)
+func (idx commentIndex) draftsForRow(row int) []review.CommentDraft {
+	drafts := make([]review.CommentDraft, 0, 1)
 	for _, entry := range idx.entries {
-		if entry.Row == row {
-			entries = append(entries, entry)
+		if entry.row == row {
+			drafts = append(drafts, entry.draft)
 		}
 	}
-	return entries
-}
-
-func (idx commentIndex) draftsForRow(row int) []review.CommentDraft {
-	entries := idx.entriesForRow(row)
-	if len(entries) == 0 {
+	if len(drafts) == 0 {
 		return nil
-	}
-	drafts := make([]review.CommentDraft, 0, len(entries))
-	for _, entry := range entries {
-		drafts = append(drafts, entry.Draft)
 	}
 	return drafts
 }
@@ -92,11 +70,11 @@ func (idx commentIndex) targetRows() []int {
 	seen := make(map[int]bool, len(idx.entries))
 	targets := make([]int, 0, len(idx.entries))
 	for _, entry := range idx.entries {
-		if seen[entry.Row] {
+		if seen[entry.row] {
 			continue
 		}
-		seen[entry.Row] = true
-		targets = append(targets, entry.Row)
+		seen[entry.row] = true
+		targets = append(targets, entry.row)
 	}
 	sort.Ints(targets)
 	return targets

--- a/tui/comment_index_test.go
+++ b/tui/comment_index_test.go
@@ -16,7 +16,7 @@ func TestBuildCommentIndexResolvesSingleLineComment(t *testing.T) {
 	drafts := []review.CommentDraft{{Path: "main.go", Line: 2, Side: review.SideRight, Body: "  looks good\nwith detail  "}}
 
 	idx := buildCommentIndex(rows, drafts)
-	entries := idx.Entries()
+	entries := idx.entries
 	if len(entries) != 1 {
 		t.Fatalf("entries = %d, want 1", len(entries))
 	}
@@ -30,8 +30,8 @@ func TestBuildCommentIndexResolvesSingleLineComment(t *testing.T) {
 	if entry.Preview != "looks good" {
 		t.Fatalf("preview = %q, want first trimmed line", entry.Preview)
 	}
-	if !reflect.DeepEqual(idx.TargetRows(), []int{1}) {
-		t.Fatalf("target rows = %#v, want []int{1}", idx.TargetRows())
+	if !reflect.DeepEqual(idx.targetRows(), []int{1}) {
+		t.Fatalf("target rows = %#v, want []int{1}", idx.targetRows())
 	}
 }
 
@@ -43,7 +43,7 @@ func TestBuildCommentIndexResolvesLeftSideComment(t *testing.T) {
 	drafts := []review.CommentDraft{{Path: "main.go", Line: 7, Side: review.SideLeft, Body: "left note"}}
 
 	idx := buildCommentIndex(rows, drafts)
-	entries := idx.Entries()
+	entries := idx.entries
 	if len(entries) != 1 || entries[0].Row != 0 || entries[0].Side != review.SideLeft {
 		t.Fatalf("entries = %+v, want one left-side entry at row 0", entries)
 	}
@@ -58,15 +58,15 @@ func TestBuildCommentIndexResolvesRangeToEndRowOnce(t *testing.T) {
 	drafts := []review.CommentDraft{{Path: "main.go", StartLine: 1, StartSide: review.SideRight, Line: 3, Side: review.SideRight, Body: "range"}}
 
 	idx := buildCommentIndex(rows, drafts)
-	entries := idx.Entries()
+	entries := idx.entries
 	if len(entries) != 1 {
 		t.Fatalf("entries = %d, want 1", len(entries))
 	}
 	if entries[0].Row != 2 || entries[0].StartLine != 1 || entries[0].Line != 3 {
 		t.Fatalf("entry = %+v, want range targeted to end row 2 with line metadata", entries[0])
 	}
-	if !reflect.DeepEqual(idx.TargetRows(), []int{2}) {
-		t.Fatalf("target rows = %#v, want []int{2}", idx.TargetRows())
+	if !reflect.DeepEqual(idx.targetRows(), []int{2}) {
+		t.Fatalf("target rows = %#v, want []int{2}", idx.targetRows())
 	}
 }
 
@@ -77,7 +77,7 @@ func TestBuildCommentIndexFallsBackToContainedRangeRow(t *testing.T) {
 	drafts := []review.CommentDraft{{Path: "main.go", StartLine: 1, StartSide: review.SideRight, Line: 3, Side: review.SideRight, Body: "range"}}
 
 	idx := buildCommentIndex(rows, drafts)
-	entries := idx.Entries()
+	entries := idx.entries
 	if len(entries) != 1 || entries[0].Row != 0 || entries[0].Line != 3 || entries[0].StartLine != 1 {
 		t.Fatalf("entries = %+v, want fallback to visible contained row while preserving line metadata", entries)
 	}
@@ -91,11 +91,11 @@ func TestBuildCommentIndexSkipsUnmatchedComments(t *testing.T) {
 	}
 
 	idx := buildCommentIndex(rows, drafts)
-	if len(idx.Entries()) != 0 {
-		t.Fatalf("entries = %+v, want unmatched comments skipped", idx.Entries())
+	if len(idx.entries) != 0 {
+		t.Fatalf("entries = %+v, want unmatched comments skipped", idx.entries)
 	}
-	if len(idx.TargetRows()) != 0 {
-		t.Fatalf("target rows = %+v, want none", idx.TargetRows())
+	if len(idx.targetRows()) != 0 {
+		t.Fatalf("target rows = %+v, want none", idx.targetRows())
 	}
 }
 
@@ -107,15 +107,15 @@ func TestBuildCommentIndexKeepsInputOrderForSameRow(t *testing.T) {
 	}
 
 	idx := buildCommentIndex(rows, drafts)
-	entries := idx.EntriesForRow(0)
+	entries := idx.entriesForRow(0)
 	if len(entries) != 2 {
 		t.Fatalf("same-row entries = %d, want 2", len(entries))
 	}
 	if entries[0].Preview != "first" || entries[1].Preview != "second" {
 		t.Fatalf("same-row preview order = %q, %q; want first, second", entries[0].Preview, entries[1].Preview)
 	}
-	if !reflect.DeepEqual(idx.TargetRows(), []int{0}) {
-		t.Fatalf("target rows = %#v, want one deduped row", idx.TargetRows())
+	if !reflect.DeepEqual(idx.targetRows(), []int{0}) {
+		t.Fatalf("target rows = %#v, want one deduped row", idx.targetRows())
 	}
 }
 

--- a/tui/comment_index_test.go
+++ b/tui/comment_index_test.go
@@ -1,0 +1,129 @@
+package tui
+
+import (
+	"reflect"
+	"testing"
+
+	"go.rockorager.dev/comview/diff"
+	"go.rockorager.dev/comview/review"
+)
+
+func TestBuildCommentIndexResolvesSingleLineComment(t *testing.T) {
+	rows := []diff.Row{
+		{Kind: diff.RowAdd, Code: "one", Review: review.Anchor{Path: "main.go", Line: 1, Side: review.SideRight}},
+		{Kind: diff.RowAdd, Code: "two", Review: review.Anchor{Path: "main.go", Line: 2, Side: review.SideRight}},
+	}
+	drafts := []review.CommentDraft{{Path: "main.go", Line: 2, Side: review.SideRight, Body: "  looks good\nwith detail  "}}
+
+	idx := buildCommentIndex(rows, drafts)
+	entries := idx.Entries()
+	if len(entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(entries))
+	}
+	entry := entries[0]
+	if entry.Row != 1 {
+		t.Fatalf("entry row = %d, want 1", entry.Row)
+	}
+	if entry.Path != "main.go" || entry.Line != 2 || entry.Side != review.SideRight {
+		t.Fatalf("entry location = %q line %d side %q, want main.go line 2 RIGHT", entry.Path, entry.Line, entry.Side)
+	}
+	if entry.Preview != "looks good" {
+		t.Fatalf("preview = %q, want first trimmed line", entry.Preview)
+	}
+	if !reflect.DeepEqual(idx.TargetRows(), []int{1}) {
+		t.Fatalf("target rows = %#v, want []int{1}", idx.TargetRows())
+	}
+}
+
+func TestBuildCommentIndexResolvesLeftSideComment(t *testing.T) {
+	rows := []diff.Row{
+		{Kind: diff.RowDelete, Code: "old", Review: review.Anchor{Path: "main.go", Line: 7, Side: review.SideLeft}},
+		{Kind: diff.RowAdd, Code: "new", Review: review.Anchor{Path: "main.go", Line: 8, Side: review.SideRight}},
+	}
+	drafts := []review.CommentDraft{{Path: "main.go", Line: 7, Side: review.SideLeft, Body: "left note"}}
+
+	idx := buildCommentIndex(rows, drafts)
+	entries := idx.Entries()
+	if len(entries) != 1 || entries[0].Row != 0 || entries[0].Side != review.SideLeft {
+		t.Fatalf("entries = %+v, want one left-side entry at row 0", entries)
+	}
+}
+
+func TestBuildCommentIndexResolvesRangeToEndRowOnce(t *testing.T) {
+	rows := []diff.Row{
+		{Kind: diff.RowAdd, Code: "one", Review: review.Anchor{Path: "main.go", Line: 1, Side: review.SideRight}},
+		{Kind: diff.RowAdd, Code: "two", Review: review.Anchor{Path: "main.go", Line: 2, Side: review.SideRight}},
+		{Kind: diff.RowAdd, Code: "three", Review: review.Anchor{Path: "main.go", Line: 3, Side: review.SideRight}},
+	}
+	drafts := []review.CommentDraft{{Path: "main.go", StartLine: 1, StartSide: review.SideRight, Line: 3, Side: review.SideRight, Body: "range"}}
+
+	idx := buildCommentIndex(rows, drafts)
+	entries := idx.Entries()
+	if len(entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(entries))
+	}
+	if entries[0].Row != 2 || entries[0].StartLine != 1 || entries[0].Line != 3 {
+		t.Fatalf("entry = %+v, want range targeted to end row 2 with line metadata", entries[0])
+	}
+	if !reflect.DeepEqual(idx.TargetRows(), []int{2}) {
+		t.Fatalf("target rows = %#v, want []int{2}", idx.TargetRows())
+	}
+}
+
+func TestBuildCommentIndexFallsBackToContainedRangeRow(t *testing.T) {
+	rows := []diff.Row{
+		{Kind: diff.RowAdd, Code: "two", Review: review.Anchor{Path: "main.go", Line: 2, Side: review.SideRight}},
+	}
+	drafts := []review.CommentDraft{{Path: "main.go", StartLine: 1, StartSide: review.SideRight, Line: 3, Side: review.SideRight, Body: "range"}}
+
+	idx := buildCommentIndex(rows, drafts)
+	entries := idx.Entries()
+	if len(entries) != 1 || entries[0].Row != 0 || entries[0].Line != 3 || entries[0].StartLine != 1 {
+		t.Fatalf("entries = %+v, want fallback to visible contained row while preserving line metadata", entries)
+	}
+}
+
+func TestBuildCommentIndexSkipsUnmatchedComments(t *testing.T) {
+	rows := []diff.Row{{Kind: diff.RowAdd, Code: "one", Review: review.Anchor{Path: "main.go", Line: 1, Side: review.SideRight}}}
+	drafts := []review.CommentDraft{
+		{Path: "other.go", Line: 1, Side: review.SideRight, Body: "wrong path"},
+		{Path: "main.go", Line: 2, Side: review.SideRight, Body: "wrong line"},
+	}
+
+	idx := buildCommentIndex(rows, drafts)
+	if len(idx.Entries()) != 0 {
+		t.Fatalf("entries = %+v, want unmatched comments skipped", idx.Entries())
+	}
+	if len(idx.TargetRows()) != 0 {
+		t.Fatalf("target rows = %+v, want none", idx.TargetRows())
+	}
+}
+
+func TestBuildCommentIndexKeepsInputOrderForSameRow(t *testing.T) {
+	rows := []diff.Row{{Kind: diff.RowAdd, Code: "one", Review: review.Anchor{Path: "main.go", Line: 1, Side: review.SideRight}}}
+	drafts := []review.CommentDraft{
+		{Path: "main.go", Line: 1, Side: review.SideRight, Body: "first"},
+		{Path: "main.go", Line: 1, Side: review.SideRight, Body: "second"},
+	}
+
+	idx := buildCommentIndex(rows, drafts)
+	entries := idx.EntriesForRow(0)
+	if len(entries) != 2 {
+		t.Fatalf("same-row entries = %d, want 2", len(entries))
+	}
+	if entries[0].Preview != "first" || entries[1].Preview != "second" {
+		t.Fatalf("same-row preview order = %q, %q; want first, second", entries[0].Preview, entries[1].Preview)
+	}
+	if !reflect.DeepEqual(idx.TargetRows(), []int{0}) {
+		t.Fatalf("target rows = %#v, want one deduped row", idx.TargetRows())
+	}
+}
+
+func TestCommentPreviewCompactsWhitespace(t *testing.T) {
+	if got := commentPreview("  first\t line  \nsecond line  "); got != "first line" {
+		t.Fatalf("preview = %q, want compact first line", got)
+	}
+	if got := commentPreview("\n\t second line "); got != "second line" {
+		t.Fatalf("preview = %q, want first non-empty trimmed line", got)
+	}
+}

--- a/tui/comment_index_test.go
+++ b/tui/comment_index_test.go
@@ -21,14 +21,17 @@ func TestBuildCommentIndexResolvesSingleLineComment(t *testing.T) {
 		t.Fatalf("entries = %d, want 1", len(entries))
 	}
 	entry := entries[0]
-	if entry.Row != 1 {
-		t.Fatalf("entry row = %d, want 1", entry.Row)
+	if entry.row != 1 {
+		t.Fatalf("entry row = %d, want 1", entry.row)
 	}
-	if entry.Path != "main.go" || entry.Line != 2 || entry.Side != review.SideRight {
-		t.Fatalf("entry location = %q line %d side %q, want main.go line 2 RIGHT", entry.Path, entry.Line, entry.Side)
+	if entry.draft.Path != "main.go" || entry.draft.Line != 2 || entry.draft.Side != review.SideRight {
+		t.Fatalf("entry draft location = %q line %d side %q, want main.go line 2 RIGHT", entry.draft.Path, entry.draft.Line, entry.draft.Side)
 	}
-	if entry.Preview != "looks good" {
-		t.Fatalf("preview = %q, want first trimmed line", entry.Preview)
+	if entry.anchor != rows[1].Review {
+		t.Fatalf("entry anchor = %+v, want row review anchor %+v", entry.anchor, rows[1].Review)
+	}
+	if got := commentPreview(entry.draft.Body); got != "looks good" {
+		t.Fatalf("preview = %q, want first trimmed line", got)
 	}
 	if !reflect.DeepEqual(idx.targetRows(), []int{1}) {
 		t.Fatalf("target rows = %#v, want []int{1}", idx.targetRows())
@@ -44,7 +47,7 @@ func TestBuildCommentIndexResolvesLeftSideComment(t *testing.T) {
 
 	idx := buildCommentIndex(rows, drafts)
 	entries := idx.entries
-	if len(entries) != 1 || entries[0].Row != 0 || entries[0].Side != review.SideLeft {
+	if len(entries) != 1 || entries[0].row != 0 || entries[0].draft.Side != review.SideLeft {
 		t.Fatalf("entries = %+v, want one left-side entry at row 0", entries)
 	}
 }
@@ -62,8 +65,8 @@ func TestBuildCommentIndexResolvesRangeToEndRowOnce(t *testing.T) {
 	if len(entries) != 1 {
 		t.Fatalf("entries = %d, want 1", len(entries))
 	}
-	if entries[0].Row != 2 || entries[0].StartLine != 1 || entries[0].Line != 3 {
-		t.Fatalf("entry = %+v, want range targeted to end row 2 with line metadata", entries[0])
+	if entries[0].row != 2 || entries[0].draft.StartLine != 1 || entries[0].draft.Line != 3 {
+		t.Fatalf("entry = %+v, want range targeted to end row 2 with draft line metadata", entries[0])
 	}
 	if !reflect.DeepEqual(idx.targetRows(), []int{2}) {
 		t.Fatalf("target rows = %#v, want []int{2}", idx.targetRows())
@@ -78,8 +81,8 @@ func TestBuildCommentIndexFallsBackToContainedRangeRow(t *testing.T) {
 
 	idx := buildCommentIndex(rows, drafts)
 	entries := idx.entries
-	if len(entries) != 1 || entries[0].Row != 0 || entries[0].Line != 3 || entries[0].StartLine != 1 {
-		t.Fatalf("entries = %+v, want fallback to visible contained row while preserving line metadata", entries)
+	if len(entries) != 1 || entries[0].row != 0 || entries[0].draft.Line != 3 || entries[0].draft.StartLine != 1 {
+		t.Fatalf("entries = %+v, want fallback to visible contained row while preserving draft line metadata", entries)
 	}
 }
 
@@ -107,12 +110,12 @@ func TestBuildCommentIndexKeepsInputOrderForSameRow(t *testing.T) {
 	}
 
 	idx := buildCommentIndex(rows, drafts)
-	entries := idx.entriesForRow(0)
-	if len(entries) != 2 {
-		t.Fatalf("same-row entries = %d, want 2", len(entries))
+	gotDrafts := idx.draftsForRow(0)
+	if len(gotDrafts) != 2 {
+		t.Fatalf("same-row drafts = %d, want 2", len(gotDrafts))
 	}
-	if entries[0].Preview != "first" || entries[1].Preview != "second" {
-		t.Fatalf("same-row preview order = %q, %q; want first, second", entries[0].Preview, entries[1].Preview)
+	if commentPreview(gotDrafts[0].Body) != "first" || commentPreview(gotDrafts[1].Body) != "second" {
+		t.Fatalf("same-row preview order = %q, %q; want first, second", commentPreview(gotDrafts[0].Body), commentPreview(gotDrafts[1].Body))
 	}
 	if !reflect.DeepEqual(idx.targetRows(), []int{0}) {
 		t.Fatalf("target rows = %#v, want one deduped row", idx.targetRows())

--- a/tui/comment_index_test.go
+++ b/tui/comment_index_test.go
@@ -24,14 +24,8 @@ func TestBuildCommentIndexResolvesSingleLineComment(t *testing.T) {
 	if entry.row != 1 {
 		t.Fatalf("entry row = %d, want 1", entry.row)
 	}
-	if entry.draft.Path != "main.go" || entry.draft.Line != 2 || entry.draft.Side != review.SideRight {
-		t.Fatalf("entry draft location = %q line %d side %q, want main.go line 2 RIGHT", entry.draft.Path, entry.draft.Line, entry.draft.Side)
-	}
-	if entry.anchor != rows[1].Review {
-		t.Fatalf("entry anchor = %+v, want row review anchor %+v", entry.anchor, rows[1].Review)
-	}
-	if got := commentPreview(entry.draft.Body); got != "looks good" {
-		t.Fatalf("preview = %q, want first trimmed line", got)
+	if entry.draft.Path != "main.go" || entry.draft.Line != 2 || entry.draft.Side != review.SideRight || entry.draft.Body != drafts[0].Body {
+		t.Fatalf("entry draft = %+v, want original draft metadata", entry.draft)
 	}
 	if !reflect.DeepEqual(idx.targetRows(), []int{1}) {
 		t.Fatalf("target rows = %#v, want []int{1}", idx.targetRows())
@@ -114,19 +108,10 @@ func TestBuildCommentIndexKeepsInputOrderForSameRow(t *testing.T) {
 	if len(gotDrafts) != 2 {
 		t.Fatalf("same-row drafts = %d, want 2", len(gotDrafts))
 	}
-	if commentPreview(gotDrafts[0].Body) != "first" || commentPreview(gotDrafts[1].Body) != "second" {
-		t.Fatalf("same-row preview order = %q, %q; want first, second", commentPreview(gotDrafts[0].Body), commentPreview(gotDrafts[1].Body))
+	if gotDrafts[0].Body != "first" || gotDrafts[1].Body != "second" {
+		t.Fatalf("same-row draft order = %q, %q; want first, second", gotDrafts[0].Body, gotDrafts[1].Body)
 	}
 	if !reflect.DeepEqual(idx.targetRows(), []int{0}) {
 		t.Fatalf("target rows = %#v, want one deduped row", idx.targetRows())
-	}
-}
-
-func TestCommentPreviewCompactsWhitespace(t *testing.T) {
-	if got := commentPreview("  first\t line  \nsecond line  "); got != "first line" {
-		t.Fatalf("preview = %q, want compact first line", got)
-	}
-	if got := commentPreview("\n\t second line "); got != "second line" {
-		t.Fatalf("preview = %q, want first non-empty trimmed line", got)
 	}
 }

--- a/tui/shared.go
+++ b/tui/shared.go
@@ -569,7 +569,7 @@ func reviewDraftContains(draft review.CommentDraft, anchor review.Anchor) bool {
 }
 
 func noteTargetRows(rows []diff.Row, drafts []review.CommentDraft) []int {
-	return buildCommentIndex(rows, drafts).TargetRows()
+	return buildCommentIndex(rows, drafts).targetRows()
 }
 
 func segmentsText(segments []vaxis.Segment) string {

--- a/tui/shared.go
+++ b/tui/shared.go
@@ -3,7 +3,6 @@ package tui
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -570,21 +569,7 @@ func reviewDraftContains(draft review.CommentDraft, anchor review.Anchor) bool {
 }
 
 func noteTargetRows(rows []diff.Row, drafts []review.CommentDraft) []int {
-	targets := make([]int, 0, len(drafts))
-	seen := make(map[int]bool, len(drafts))
-	for _, draft := range drafts {
-		for index, row := range rows {
-			if reviewDraftContains(draft, row.Review) {
-				if !seen[index] {
-					targets = append(targets, index)
-					seen[index] = true
-				}
-				break
-			}
-		}
-	}
-	sort.Ints(targets)
-	return targets
+	return buildCommentIndex(rows, drafts).TargetRows()
 }
 
 func segmentsText(segments []vaxis.Segment) string {

--- a/tui/ui_diff_viewer.go
+++ b/tui/ui_diff_viewer.go
@@ -162,6 +162,7 @@ func (s *uiDiffViewState) Build(ctx vui.BuildContext) vui.Widget {
 	highlightedRows := s.highlightedCodeRows(w.Rows, theme)
 	metrics := s.documentMetrics(w.Rows)
 	drafts := s.allReviewDrafts(w.ReviewDrafts)
+	commentIdx := buildCommentIndex(w.Rows, drafts)
 	sliver := vui.Widget(vui.SliverListBuilder{
 		Controller:          &s.list,
 		Count:               len(w.Rows),
@@ -169,7 +170,7 @@ func (s *uiDiffViewState) Build(ctx vui.BuildContext) vui.Widget {
 		EstimatedItemExtent: 1,
 		Overscan:            8,
 		Builder: func(ctx vui.BuildContext, row int) vui.Widget {
-			return s.buildItem(w.Rows, row, theme, highlightedRows, drafts, w.Wrap, metrics)
+			return s.buildItem(w.Rows, row, theme, highlightedRows, commentIdx, w.Wrap, metrics)
 		},
 	})
 	if s.sideBySide {
@@ -181,7 +182,7 @@ func (s *uiDiffViewState) Build(ctx vui.BuildContext) vui.Widget {
 			EstimatedItemExtent: 1,
 			Overscan:            8,
 			Builder: func(ctx vui.BuildContext, row int) vui.Widget {
-				return s.buildSideBySideItem(w.Rows, sideRows[row], theme, highlightedRows, drafts, w.Wrap, metrics)
+				return s.buildSideBySideItem(w.Rows, sideRows[row], theme, highlightedRows, commentIdx, w.Wrap, metrics)
 			},
 		}
 	}
@@ -1138,11 +1139,11 @@ func (s *uiDiffViewState) HandleEvent(ctx vui.EventContext, ev vui.Event) vui.Ev
 		return vui.EventHandled
 	case key.Matches('n') && s.pendingBracket == ']':
 		s.clearPendingKeys()
-		s.jumpNote(w.Rows, w.ReviewDrafts, 1)
+		s.jumpNote(w.Rows, s.allReviewDrafts(w.ReviewDrafts), 1)
 		return vui.EventHandled
 	case key.Matches('n') && s.pendingBracket == '[':
 		s.clearPendingKeys()
-		s.jumpNote(w.Rows, w.ReviewDrafts, -1)
+		s.jumpNote(w.Rows, s.allReviewDrafts(w.ReviewDrafts), -1)
 		return vui.EventHandled
 	case w.Binds.Matches(key, "search"):
 		s.clearPendingKeys()
@@ -3047,7 +3048,7 @@ func (s *uiDiffViewState) clearSearch() {
 	s.searchIndex = -1
 }
 
-func (s *uiDiffViewState) buildItem(rows []diff.Row, rowIndex int, theme vui.Theme, highlightedRows map[int][]vaxis.Segment, drafts []review.CommentDraft, wrap bool, metrics uiDiffDocumentMetrics) vui.Widget {
+func (s *uiDiffViewState) buildItem(rows []diff.Row, rowIndex int, theme vui.Theme, highlightedRows map[int][]vaxis.Segment, comments commentIndex, wrap bool, metrics uiDiffDocumentMetrics) vui.Widget {
 	row := rows[rowIndex]
 	active := rowIndex == s.cursor.Row && !s.commentEditorInsert && !s.commentEditorFocused
 	selected := s.lineSelected(rowIndex)
@@ -3070,7 +3071,7 @@ func (s *uiDiffViewState) buildItem(rows []diff.Row, rowIndex int, theme vui.The
 		showDrafts = false
 	}
 	if showDrafts {
-		for _, draft := range reviewDraftsForRow(row, drafts) {
+		for _, draft := range comments.DraftsForRow(rowIndex) {
 			children = append(children, uiDiffIndentedComment(commentIndent, uiDiffReviewDraft(draft, theme, func(vui.EventContext) {
 				s.focusCommentEditorRow(rows, rowIndex)
 				s.commentEditorInsert = true
@@ -3083,9 +3084,9 @@ func (s *uiDiffViewState) buildItem(rows []diff.Row, rowIndex int, theme vui.The
 	return vui.Column(children...)
 }
 
-func (s *uiDiffViewState) buildSideBySideItem(rows []diff.Row, sideRow sideBySideRow, theme vui.Theme, highlightedRows map[int][]vaxis.Segment, drafts []review.CommentDraft, wrap bool, metrics uiDiffDocumentMetrics) vui.Widget {
+func (s *uiDiffViewState) buildSideBySideItem(rows []diff.Row, sideRow sideBySideRow, theme vui.Theme, highlightedRows map[int][]vaxis.Segment, comments commentIndex, wrap bool, metrics uiDiffDocumentMetrics) vui.Widget {
 	if sideRow.Full >= 0 {
-		return s.buildItem(rows, sideRow.Full, theme, highlightedRows, drafts, wrap, metrics)
+		return s.buildItem(rows, sideRow.Full, theme, highlightedRows, comments, wrap, metrics)
 	}
 	separatorStyle := vaxis.Style{Foreground: theme.MutedForeground, Background: theme.Background}
 	row := vui.Row(
@@ -3095,7 +3096,7 @@ func (s *uiDiffViewState) buildSideBySideItem(rows []diff.Row, sideRow sideBySid
 	)
 	children := []vui.Widget{row}
 	for _, docRow := range sideBySideRowCommentDocRows(sideRow) {
-		children = append(children, s.buildSideBySideCommentRows(rows, docRow, drafts, theme, metrics)...)
+		children = append(children, s.buildSideBySideCommentRows(rows, docRow, comments, theme, metrics)...)
 	}
 	if len(children) == 1 {
 		return row
@@ -3199,7 +3200,7 @@ func uiDiffSplitSideBySideGutter(gutter string) (string, string) {
 	return gutter[:len(gutter)-3], gutter[len(gutter)-3:]
 }
 
-func (s *uiDiffViewState) buildSideBySideCommentRows(rows []diff.Row, rowIndex int, drafts []review.CommentDraft, theme vui.Theme, metrics uiDiffDocumentMetrics) []vui.Widget {
+func (s *uiDiffViewState) buildSideBySideCommentRows(rows []diff.Row, rowIndex int, comments commentIndex, theme vui.Theme, metrics uiDiffDocumentMetrics) []vui.Widget {
 	if rowIndex < 0 || rowIndex >= len(rows) {
 		return nil
 	}
@@ -3219,7 +3220,7 @@ func (s *uiDiffViewState) buildSideBySideCommentRows(rows []diff.Row, rowIndex i
 		showDrafts = false
 	}
 	if showDrafts {
-		for _, draft := range reviewDraftsForRow(rows[rowIndex], drafts) {
+		for _, draft := range comments.DraftsForRow(rowIndex) {
 			addCommentWidget(uiDiffReviewDraft(draft, theme, func(vui.EventContext) {
 				s.focusCommentEditorRow(rows, rowIndex)
 				s.commentEditorInsert = true

--- a/tui/ui_diff_viewer.go
+++ b/tui/ui_diff_viewer.go
@@ -535,6 +535,11 @@ func (s *uiDiffViewState) allReviewDrafts(base []review.CommentDraft) []review.C
 	return drafts
 }
 
+func (s *uiDiffViewState) commentIndex(rows []diff.Row) commentIndex {
+	w := s.Widget().(uiDiffView)
+	return buildCommentIndex(rows, s.allReviewDrafts(w.ReviewDrafts))
+}
+
 type uiDiffFileItem struct {
 	Label  string
 	Detail string
@@ -1477,9 +1482,10 @@ func (s *uiDiffViewState) commentItemRowAndOffsetForMouse(rows []diff.Row, mouse
 		}
 		logicalY = metrics.ScrollOffset + mouse.Row
 	}
+	comments := s.commentIndex(rows)
 	visualY := 0
 	for rowIndex := range rows {
-		height := 1 + s.commentRowsForMouse(rows, rowIndex)
+		height := 1 + s.commentRowsForMouse(rows, rowIndex, comments)
 		if logicalY >= visualY && logicalY < visualY+height {
 			return rowIndex, logicalY - visualY, true
 		}
@@ -1488,7 +1494,7 @@ func (s *uiDiffViewState) commentItemRowAndOffsetForMouse(rows []diff.Row, mouse
 	return 0, 0, false
 }
 
-func (s *uiDiffViewState) commentRowsForMouse(rows []diff.Row, row int) int {
+func (s *uiDiffViewState) commentRowsForMouse(rows []diff.Row, row int, comments commentIndex) int {
 	if row < 0 || row >= len(rows) {
 		return 0
 	}
@@ -1498,9 +1504,8 @@ func (s *uiDiffViewState) commentRowsForMouse(rows []diff.Row, row int) int {
 	if strings.TrimSpace(s.commentEditorBodies[row]) != "" {
 		return uiDiffCommentEditorRows(s.commentEditorBodies[row])
 	}
-	w := s.Widget().(uiDiffView)
 	count := 0
-	for _, draft := range reviewDraftsForRow(rows[row], s.allReviewDrafts(w.ReviewDrafts)) {
+	for _, draft := range comments.DraftsForRow(row) {
 		count += uiDiffCommentEditorRows(draft.Body)
 	}
 	return count
@@ -1964,10 +1969,8 @@ func (s *uiDiffViewState) reviewDraftForSelection(rows []diff.Row) (review.Comme
 }
 
 func (s *uiDiffViewState) reviewDraftTargetRow(rows []diff.Row, draft review.CommentDraft) int {
-	for rowIndex, row := range rows {
-		if reviewDraftEndsAt(draft, row.Review) {
-			return rowIndex
-		}
+	if row, ok := commentIndexTargetRow(rows, draft); ok {
+		return row
 	}
 	return s.cursor.Row
 }
@@ -2347,6 +2350,7 @@ func (s *uiDiffViewState) hasUnsavedReviewChanges(rows []diff.Row) bool {
 			return true
 		}
 	}
+	comments := s.commentIndex(rows)
 	for row, body := range s.commentEditorBodies {
 		if strings.TrimSpace(body) == "" {
 			continue
@@ -2354,8 +2358,7 @@ func (s *uiDiffViewState) hasUnsavedReviewChanges(rows []diff.Row) bool {
 		if row < 0 || row >= len(rows) {
 			return true
 		}
-		w := s.Widget().(uiDiffView)
-		drafts := reviewDraftsForRow(rows[row], s.allReviewDrafts(w.ReviewDrafts))
+		drafts := comments.DraftsForRow(row)
 		if len(drafts) == 0 || body != drafts[0].Body {
 			return true
 		}
@@ -2619,8 +2622,7 @@ func (s *uiDiffViewState) commentEditorBodyForRow(rows []diff.Row, row int) stri
 	if row < 0 || row >= len(rows) {
 		return ""
 	}
-	w := s.Widget().(uiDiffView)
-	drafts := reviewDraftsForRow(rows[row], s.allReviewDrafts(w.ReviewDrafts))
+	drafts := s.commentIndex(rows).DraftsForRow(row)
 	if len(drafts) == 0 {
 		return ""
 	}
@@ -2629,6 +2631,7 @@ func (s *uiDiffViewState) commentEditorBodyForRow(rows []diff.Row, row int) stri
 
 func (s *uiDiffViewState) focusCommentEditorRow(rows []diff.Row, row int) {
 	s.storeCommentEditorBody()
+	comments := s.commentIndex(rows)
 	body := s.commentEditorBodyForRow(rows, row)
 	s.commentEditorActive = true
 	s.commentEditorFocused = true
@@ -2637,8 +2640,7 @@ func (s *uiDiffViewState) focusCommentEditorRow(rows []diff.Row, row int) {
 	s.commentEditorCursor = nil
 	s.commentEditorTarget = uiDiffCommentTarget{Row: row}
 	if row >= 0 && row < len(rows) {
-		w := s.Widget().(uiDiffView)
-		if drafts := reviewDraftsForRow(rows[row], s.allReviewDrafts(w.ReviewDrafts)); len(drafts) > 0 {
+		if drafts := comments.DraftsForRow(row); len(drafts) > 0 {
 			s.commentEditorTarget.Draft = drafts[0]
 		}
 	}
@@ -3538,19 +3540,6 @@ func uiDiffIndentedComment(indent int, child vui.Widget, theme vui.Theme) vui.Wi
 		uiDiffFixedCell(indent, style, vui.Text{Value: strings.Repeat(" ", indent), Style: style}),
 		child,
 	)
-}
-
-func reviewDraftsForRow(row diff.Row, drafts []review.CommentDraft) []review.CommentDraft {
-	if !reviewAnchorValid(row.Review) {
-		return nil
-	}
-	matches := make([]review.CommentDraft, 0, 1)
-	for _, draft := range drafts {
-		if reviewDraftEndsAt(draft, row.Review) {
-			matches = append(matches, draft)
-		}
-	}
-	return matches
 }
 
 func uiDiffRowBackground(active bool, selected bool, yanked bool, theme vui.Theme) vaxis.Color {

--- a/tui/ui_diff_viewer.go
+++ b/tui/ui_diff_viewer.go
@@ -1505,7 +1505,7 @@ func (s *uiDiffViewState) commentRowsForMouse(rows []diff.Row, row int, comments
 		return uiDiffCommentEditorRows(s.commentEditorBodies[row])
 	}
 	count := 0
-	for _, draft := range comments.DraftsForRow(row) {
+	for _, draft := range comments.draftsForRow(row) {
 		count += uiDiffCommentEditorRows(draft.Body)
 	}
 	return count
@@ -2358,7 +2358,7 @@ func (s *uiDiffViewState) hasUnsavedReviewChanges(rows []diff.Row) bool {
 		if row < 0 || row >= len(rows) {
 			return true
 		}
-		drafts := comments.DraftsForRow(row)
+		drafts := comments.draftsForRow(row)
 		if len(drafts) == 0 || body != drafts[0].Body {
 			return true
 		}
@@ -2613,6 +2613,10 @@ func (s *uiDiffViewState) moveIntoCommentEditor(rows []diff.Row, delta int) bool
 }
 
 func (s *uiDiffViewState) commentEditorBodyForRow(rows []diff.Row, row int) string {
+	return s.commentEditorBodyForRowWithIndex(rows, row, s.commentIndex(rows))
+}
+
+func (s *uiDiffViewState) commentEditorBodyForRowWithIndex(rows []diff.Row, row int, comments commentIndex) string {
 	if s.commentEditorActive && s.commentEditorRow == row && strings.TrimSpace(s.commentEditorBody) != "" {
 		return s.commentEditorBody
 	}
@@ -2622,7 +2626,7 @@ func (s *uiDiffViewState) commentEditorBodyForRow(rows []diff.Row, row int) stri
 	if row < 0 || row >= len(rows) {
 		return ""
 	}
-	drafts := s.commentIndex(rows).DraftsForRow(row)
+	drafts := comments.draftsForRow(row)
 	if len(drafts) == 0 {
 		return ""
 	}
@@ -2632,7 +2636,7 @@ func (s *uiDiffViewState) commentEditorBodyForRow(rows []diff.Row, row int) stri
 func (s *uiDiffViewState) focusCommentEditorRow(rows []diff.Row, row int) {
 	s.storeCommentEditorBody()
 	comments := s.commentIndex(rows)
-	body := s.commentEditorBodyForRow(rows, row)
+	body := s.commentEditorBodyForRowWithIndex(rows, row, comments)
 	s.commentEditorActive = true
 	s.commentEditorFocused = true
 	s.commentEditorInsert = false
@@ -2640,7 +2644,7 @@ func (s *uiDiffViewState) focusCommentEditorRow(rows []diff.Row, row int) {
 	s.commentEditorCursor = nil
 	s.commentEditorTarget = uiDiffCommentTarget{Row: row}
 	if row >= 0 && row < len(rows) {
-		if drafts := comments.DraftsForRow(row); len(drafts) > 0 {
+		if drafts := comments.draftsForRow(row); len(drafts) > 0 {
 			s.commentEditorTarget.Draft = drafts[0]
 		}
 	}
@@ -3073,7 +3077,7 @@ func (s *uiDiffViewState) buildItem(rows []diff.Row, rowIndex int, theme vui.The
 		showDrafts = false
 	}
 	if showDrafts {
-		for _, draft := range comments.DraftsForRow(rowIndex) {
+		for _, draft := range comments.draftsForRow(rowIndex) {
 			children = append(children, uiDiffIndentedComment(commentIndent, uiDiffReviewDraft(draft, theme, func(vui.EventContext) {
 				s.focusCommentEditorRow(rows, rowIndex)
 				s.commentEditorInsert = true
@@ -3222,7 +3226,7 @@ func (s *uiDiffViewState) buildSideBySideCommentRows(rows []diff.Row, rowIndex i
 		showDrafts = false
 	}
 	if showDrafts {
-		for _, draft := range comments.DraftsForRow(rowIndex) {
+		for _, draft := range comments.draftsForRow(rowIndex) {
 			addCommentWidget(uiDiffReviewDraft(draft, theme, func(vui.EventContext) {
 				s.focusCommentEditorRow(rows, rowIndex)
 				s.commentEditorInsert = true

--- a/tui/ui_diff_viewer_test.go
+++ b/tui/ui_diff_viewer_test.go
@@ -1936,6 +1936,51 @@ func TestUIDiffViewBracketNJumpsBetweenNotes(t *testing.T) {
 	}
 }
 
+func TestUIDiffViewBracketNJumpsBetweenNewSessionNotes(t *testing.T) {
+	rows := []diff.Row{
+		{Kind: diff.RowAdd, Gutter: "1 1 + ", Code: "one", Review: review.Anchor{Path: "main.go", Line: 1, Side: review.SideRight}},
+		{Kind: diff.RowAdd, Gutter: "2 2 + ", Code: "two", Review: review.Anchor{Path: "main.go", Line: 2, Side: review.SideRight}},
+		{Kind: diff.RowAdd, Gutter: "3 3 + ", Code: "three", Review: review.Anchor{Path: "main.go", Line: 3, Side: review.SideRight}},
+	}
+	app := newUIDiffTestAppWithBaseDraftsAndStatus(rows, DefaultBaseColors(), false, nil, true)
+	size := vui.Size{Width: 80, Height: 12}
+	app.Pump(size)
+	app.Pump(size)
+
+	app.Send(vaxis.Key{Text: "j", Keycode: 'j'})
+	app.Send(vaxis.Key{Text: "i", Keycode: 'i'})
+	app.Pump(size)
+	app.Send(vaxis.Key{Text: "first"})
+	app.Send(vaxis.Key{Text: "s", Keycode: 's', Modifiers: vaxis.ModCtrl})
+	app.Pump(size)
+
+	app.Send(vaxis.Key{Text: "j", Keycode: 'j'})
+	app.Send(vaxis.Key{Text: "j", Keycode: 'j'})
+	app.Send(vaxis.Key{Text: "i", Keycode: 'i'})
+	app.Pump(size)
+	app.Send(vaxis.Key{Text: "second"})
+	app.Send(vaxis.Key{Text: "s", Keycode: 's', Modifiers: vaxis.ModCtrl})
+	app.Pump(size)
+
+	app.Send(vaxis.Key{Text: "[", Keycode: '['})
+	app.Send(vaxis.Key{Text: "n", Keycode: 'n'})
+	app.Pump(size)
+	p := vui.NewPainter(size)
+	app.Paint(p)
+	if got := uiDiffHighlightedScreenRow(p, uiDiffCursorRowBackground(uiDiffTestTheme())); got != 1 {
+		t.Fatalf("[n newly-created note highlight row = %d, want first note row 1", got)
+	}
+
+	app.Send(vaxis.Key{Text: "]", Keycode: ']'})
+	app.Send(vaxis.Key{Text: "n", Keycode: 'n'})
+	app.Pump(size)
+	p = vui.NewPainter(size)
+	app.Paint(p)
+	if got := uiDiffHighlightedScreenRow(p, uiDiffCursorRowBackground(uiDiffTestTheme())); got != 5 {
+		t.Fatalf("]n newly-created note highlight row = %d, want second note row 5", got)
+	}
+}
+
 func TestUIDiffViewBracketNJumpsToRangeCommentTargetOnce(t *testing.T) {
 	rows := []diff.Row{
 		{Kind: diff.RowAdd, Gutter: "1 1   ", Code: "one", Review: review.Anchor{Path: "main.go", Line: 1, Side: review.SideRight}},

--- a/tui/ui_diff_viewer_test.go
+++ b/tui/ui_diff_viewer_test.go
@@ -1936,6 +1936,38 @@ func TestUIDiffViewBracketNJumpsBetweenNotes(t *testing.T) {
 	}
 }
 
+func TestUIDiffViewBracketNJumpsToRangeCommentTargetOnce(t *testing.T) {
+	rows := []diff.Row{
+		{Kind: diff.RowAdd, Gutter: "1 1   ", Code: "one", Review: review.Anchor{Path: "main.go", Line: 1, Side: review.SideRight}},
+		{Kind: diff.RowAdd, Gutter: "2 2   ", Code: "two", Review: review.Anchor{Path: "main.go", Line: 2, Side: review.SideRight}},
+		{Kind: diff.RowAdd, Gutter: "3 3   ", Code: "three", Review: review.Anchor{Path: "main.go", Line: 3, Side: review.SideRight}},
+	}
+	drafts := []review.CommentDraft{{Path: "main.go", StartLine: 1, StartSide: review.SideRight, Line: 3, Side: review.SideRight, Body: "range"}}
+	app := newUIDiffTestAppWithBaseAndDrafts(rows, DefaultBaseColors(), false, drafts)
+	size := vui.Size{Width: 24, Height: 7}
+	app.Pump(size)
+	app.Pump(size)
+
+	app.Send(vaxis.Key{Text: "]", Keycode: ']'})
+	app.Send(vaxis.Key{Text: "n", Keycode: 'n'})
+	app.Pump(size)
+
+	p := vui.NewPainter(size)
+	app.Paint(p)
+	if got := uiDiffHighlightedScreenRow(p, uiDiffCursorRowBackground(uiDiffTestTheme())); got != 2 {
+		t.Fatalf("]n range highlight row = %d, want end row 2", got)
+	}
+
+	app.Send(vaxis.Key{Text: "]", Keycode: ']'})
+	app.Send(vaxis.Key{Text: "n", Keycode: 'n'})
+	app.Pump(size)
+	p = vui.NewPainter(size)
+	app.Paint(p)
+	if got := uiDiffHighlightedScreenRow(p, uiDiffCursorRowBackground(uiDiffTestTheme())); got != 2 {
+		t.Fatalf("second ]n range highlight row = %d, want unchanged row 2", got)
+	}
+}
+
 func TestUIDiffViewSlashSearchMovesToMatch(t *testing.T) {
 	rows := []diff.Row{
 		{Kind: diff.RowContext, Gutter: "1 1   ", Code: "alpha"},


### PR DESCRIPTION
## Summary

This adds a small internal index for review comments.

Comview already has a few places that need to answer the same question: where does this comment live in the current diff? Rendering, mouse handling, edit state, and note navigation were each doing bits of that work themselves.

This PR makes that lookup one shared path. It resolves saved and local comment drafts against the visible diff rows, skips comments that no longer match the current diff, and makes range comments land on one target row.

## Why

I’m working toward making comment navigation a bit less fiddly.

The next steps I have in mind are:

- Fix `]n` / `[n` note navigation so it always follows indexed comment targets: https://github.com/deevus/comview/issues/2
- Add a searchable comment picker on `<space>n`: https://github.com/deevus/comview/issues/3
- Update the help text and README once the picker exists: https://github.com/deevus/comview/issues/4

Those issues are in my fork for now. They are mainly there to show the shape and order of the work.

This PR is the base piece. It keeps the persisted comment format alone and avoids adding picker UI before there is something using it.

## Testing

- `mise run check`
