### PR TITLE
Add searchable comment picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Comments are saved to `.comview/comments.json`.
 | `s` | Toggle side-by-side view |
 | `t` | Choose theme |
 | `<space>e` | Find file in diff |
+| `<space>n` | Find comment |
 | `/` | Search |
 | `n` / `N` | Next / previous search result |
 | `o` | Open cursor location in editor |

--- a/tui/shared.go
+++ b/tui/shared.go
@@ -120,6 +120,7 @@ var helpKeybinds = []helpKeybind{
 	{Key: "s", READMEKey: "`s`", Action: "Toggle side-by-side view"},
 	{Key: "t", READMEKey: "`t`", Action: "Choose theme"},
 	{Key: "Space e", READMEKey: "`<space>e`", Action: "Find file in diff"},
+	{Key: "Space n", READMEKey: "`<space>n`", Action: "Find comment"},
 	{Key: "/", READMEKey: "`/`", Action: "Search"},
 	{Key: "n / N", READMEKey: "`n` / `N`", Action: "Next / previous search result"},
 	{Key: "o", READMEKey: "`o`", Action: "Open cursor location in editor"},

--- a/tui/ui_diff_viewer.go
+++ b/tui/ui_diff_viewer.go
@@ -71,6 +71,7 @@ type uiDiffViewState struct {
 	pendingSpace              bool
 	pendingD                  bool
 	fileFinder                bool
+	commentFinder             bool
 	themeFinder               bool
 	themeName                 string
 	themeNameBeforePick       string
@@ -232,6 +233,9 @@ func (s *uiDiffViewState) Build(ctx vui.BuildContext) vui.Widget {
 	entries := []vui.OverlayEntry{}
 	if s.fileFinder {
 		entries = append(entries, vui.OverlayEntry{Modal: true, Child: s.buildFileFinder(w.Rows, theme)})
+	}
+	if s.commentFinder {
+		entries = append(entries, vui.OverlayEntry{Modal: true, Child: s.buildCommentFinder(w.Rows, commentIdx)})
 	}
 	if s.themeFinder {
 		entries = append(entries, vui.OverlayEntry{Modal: true, Child: s.buildThemeFinder()})
@@ -602,6 +606,69 @@ func uiDiffFileFinderItems(rows []diff.Row) []uiDiffFileItem {
 		}
 	}
 	return items
+}
+
+type uiDiffCommentItem struct {
+	Label   string
+	Preview string
+	Row     int
+}
+
+func (s *uiDiffViewState) buildCommentFinder(rows []diff.Row, idx commentIndex) vui.Widget {
+	return vui.FuzzySelect[uiDiffCommentItem]{
+		Items:          uiDiffCommentFinderItems(idx),
+		Item:           uiDiffCommentSelectItem,
+		Placeholder:    "Find comment…",
+		EmptyText:      "No matching comments",
+		MaxVisibleRows: 8,
+		RowStyle:       vui.FuzzySelectOneLine,
+		OnDismiss: func(vui.EventContext) {
+			s.commentFinder = false
+			s.SetState(func() {})
+		},
+		OnSelected: func(_ vui.EventContext, item uiDiffCommentItem) {
+			s.commentFinder = false
+			s.setCursorRowAtStart(rows, item.Row)
+		},
+	}
+}
+
+func uiDiffCommentFinderItems(idx commentIndex) []uiDiffCommentItem {
+	items := make([]uiDiffCommentItem, 0, len(idx.entries))
+	for _, entry := range idx.entries {
+		items = append(items, uiDiffCommentItem{
+			Label:   uiDiffCommentLocation(entry.draft),
+			Preview: uiDiffCommentPreview(entry.draft.Body),
+			Row:     entry.row,
+		})
+	}
+	return items
+}
+
+func uiDiffCommentSelectItem(item uiDiffCommentItem) vui.FuzzySelectItem {
+	return vui.FuzzySelectItem{
+		Title:       item.Label,
+		Description: item.Preview,
+		Aliases:     []string{item.Label, item.Preview},
+		Trailing:    vui.Text{Value: item.Preview, MaxLines: 1, Overflow: vui.TextOverflowEllipsis},
+	}
+}
+
+func uiDiffCommentLocation(draft review.CommentDraft) string {
+	if draft.StartLine != 0 && draft.StartLine != draft.Line {
+		return fmt.Sprintf("%s:%d-%d", draft.Path, draft.StartLine, draft.Line)
+	}
+	return fmt.Sprintf("%s:%d", draft.Path, draft.Line)
+}
+
+func uiDiffCommentPreview(body string) string {
+	for _, line := range strings.Split(body, "\n") {
+		preview := strings.Join(strings.Fields(line), " ")
+		if preview != "" {
+			return preview
+		}
+	}
+	return "(empty comment)"
 }
 
 func uiDiffFileStatsFromRow(rows []diff.Row, fileRow int) statusStats {
@@ -1052,6 +1119,9 @@ func (s *uiDiffViewState) HandleEvent(ctx vui.EventContext, ev vui.Event) vui.Ev
 	if s.fileFinder {
 		return vui.EventIgnored
 	}
+	if s.commentFinder {
+		return vui.EventIgnored
+	}
 	if s.themeFinder {
 		return vui.EventIgnored
 	}
@@ -1198,6 +1268,15 @@ func (s *uiDiffViewState) HandleEvent(ctx vui.EventContext, ev vui.Event) vui.Ev
 			return vui.EventHandled
 		}
 		s.fileFinder = true
+		s.SetState(func() {})
+		return vui.EventHandled
+	case key.Matches('n') && s.pendingSpace:
+		s.clearPendingKeys()
+		commentIdx := buildCommentIndex(rows, s.allReviewDrafts(w.ReviewDrafts))
+		if len(uiDiffCommentFinderItems(commentIdx)) == 0 {
+			return vui.EventHandled
+		}
+		s.commentFinder = true
 		s.SetState(func() {})
 		return vui.EventHandled
 	case w.Binds.Matches(key, "next_result"):

--- a/tui/ui_diff_viewer.go
+++ b/tui/ui_diff_viewer.go
@@ -1377,7 +1377,7 @@ func (s *uiDiffViewState) HandleEvent(ctx vui.EventContext, ev vui.Event) vui.Ev
 }
 
 func (s *uiDiffViewState) handleMouse(_ vui.EventContext, mouse vaxis.Mouse) vui.EventResult {
-	if s.fileFinder {
+	if s.fileFinder || s.commentFinder {
 		return vui.EventIgnored
 	}
 	w := s.Widget().(uiDiffView)
@@ -4392,7 +4392,13 @@ func (s *uiDiffViewState) jumpCommit(rows []diff.Row, direction int) {
 
 func (s *uiDiffViewState) setCursorRowAtStart(rows []diff.Row, row int) {
 	s.setCursorRow(rows, row)
-	s.list.ScrollToIndex(s.cursor.Row, vui.ScrollAlignStart)
+	visualRow := s.cursor.Row
+	if s.sideBySide {
+		if row, ok := uiDiffSideBySideVisualIndex(rows, visualRow); ok {
+			visualRow = row
+		}
+	}
+	s.list.ScrollToIndex(visualRow, vui.ScrollAlignStart)
 }
 
 func (s *uiDiffViewState) jumpChange(rows []diff.Row, direction int) {

--- a/tui/ui_diff_viewer_test.go
+++ b/tui/ui_diff_viewer_test.go
@@ -558,6 +558,128 @@ func TestUIDiffViewFileFinderConsumesDiffKeys(t *testing.T) {
 	}
 }
 
+func TestUIDiffViewCommentFinderOpensWithIndexedComments(t *testing.T) {
+	rows := []diff.Row{
+		{Kind: diff.RowAdd, Gutter: "1 1   ", Code: "first", Review: review.Anchor{Path: "main.go", Line: 1, Side: review.SideRight}},
+		{Kind: diff.RowAdd, Gutter: "2 2   ", Code: "second", Review: review.Anchor{Path: "main.go", Line: 2, Side: review.SideRight}},
+	}
+	drafts := []review.CommentDraft{{Path: "main.go", Line: 2, Side: review.SideRight, Body: "  second body preview\nmore detail"}}
+	app := newUIDiffTestAppWithBaseDraftsAndStatus(rows, DefaultBaseColors(), false, drafts, true)
+	size := vui.Size{Width: 80, Height: 8}
+	app.Pump(size)
+	app.Pump(size)
+
+	app.Send(vaxis.Key{Text: " ", Keycode: vaxis.KeySpace})
+	app.Send(vaxis.Key{Text: "n", Keycode: 'n'})
+	app.Pump(size)
+
+	p := vui.NewPainter(size)
+	app.Paint(p)
+	if _, _, ok := uiDiffFindText(p, "Find comment…"); !ok {
+		t.Fatal("comment finder did not open")
+	}
+	if _, _, ok := uiDiffFindText(p, "main.go:2"); !ok {
+		t.Fatal("comment finder item omitted comment location")
+	}
+	if _, _, ok := uiDiffFindText(p, "second body preview"); !ok {
+		t.Fatal("comment finder item omitted body preview")
+	}
+}
+
+func TestUIDiffViewCommentFinderJumpsToSelectedComment(t *testing.T) {
+	rows := []diff.Row{
+		{Kind: diff.RowAdd, Gutter: "1 1   ", Code: "alpha", Review: review.Anchor{Path: "main.go", Line: 1, Side: review.SideRight}},
+		{Kind: diff.RowAdd, Gutter: "2 2   ", Code: "middle", Review: review.Anchor{Path: "main.go", Line: 2, Side: review.SideRight}},
+		{Kind: diff.RowAdd, Gutter: "3 3   ", Code: "beta", Review: review.Anchor{Path: "main.go", Line: 3, Side: review.SideRight}},
+	}
+	drafts := []review.CommentDraft{
+		{Path: "main.go", Line: 1, Side: review.SideRight, Body: "alpha note"},
+		{Path: "main.go", Line: 3, Side: review.SideRight, Body: "beta selected note"},
+	}
+	app := newUIDiffTestAppWithBaseDraftsAndStatus(rows, DefaultBaseColors(), false, drafts, true)
+	size := vui.Size{Width: 80, Height: 8}
+	app.Pump(size)
+	app.Pump(size)
+
+	app.Send(vaxis.Key{Text: " ", Keycode: vaxis.KeySpace})
+	app.Send(vaxis.Key{Text: "n", Keycode: 'n'})
+	app.Pump(size)
+	app.Send(vaxis.Key{Text: "beta"})
+	app.Pump(size)
+	app.Send(vaxis.Key{Keycode: vaxis.KeyEnter})
+	app.Pump(size)
+	app.Pump(size)
+
+	p := vui.NewPainter(size)
+	app.Paint(p)
+	col, row, ok := uiDiffFindText(p, "3 3   beta")
+	if !ok {
+		t.Fatal("selected comment target row is not visible")
+	}
+	if got := p.Cell(col, row).Background; got != uiDiffCursorRowBackground(uiDiffTestTheme()) {
+		t.Fatalf("selected comment target background = %v, want cursor row background", got)
+	}
+	if _, _, ok := uiDiffFindText(p, "Find comment…"); ok {
+		t.Fatal("comment finder stayed visible after selection")
+	}
+}
+
+func TestUIDiffViewCommentFinderDoesNotOpenWithoutIndexedComments(t *testing.T) {
+	rows := []diff.Row{
+		{Kind: diff.RowAdd, Gutter: "1 1   ", Code: "first", Review: review.Anchor{Path: "main.go", Line: 1, Side: review.SideRight}},
+	}
+	drafts := []review.CommentDraft{{Path: "main.go", Line: 99, Side: review.SideRight, Body: "unmatched"}}
+	app := newUIDiffTestAppWithBaseDraftsAndStatus(rows, DefaultBaseColors(), false, drafts, true)
+	size := vui.Size{Width: 60, Height: 6}
+	app.Pump(size)
+	app.Pump(size)
+
+	app.Send(vaxis.Key{Text: " ", Keycode: vaxis.KeySpace})
+	app.Send(vaxis.Key{Text: "n", Keycode: 'n'})
+	app.Pump(size)
+
+	p := vui.NewPainter(size)
+	app.Paint(p)
+	if _, _, ok := uiDiffFindText(p, "Find comment…"); ok {
+		t.Fatal("comment finder opened without indexed comments")
+	}
+	if got := uiDiffHighlightedScreenRow(p, uiDiffCursorRowBackground(uiDiffTestTheme())); got != 0 {
+		t.Fatalf("cursor row = %d, want unchanged row 0", got)
+	}
+}
+
+func TestUIDiffViewCommentFinderConsumesDiffKeys(t *testing.T) {
+	rows := []diff.Row{
+		{Kind: diff.RowAdd, Gutter: "1 1   ", Code: "first", Review: review.Anchor{Path: "main.go", Line: 1, Side: review.SideRight}},
+		{Kind: diff.RowAdd, Gutter: "2 2   ", Code: "second", Review: review.Anchor{Path: "main.go", Line: 2, Side: review.SideRight}},
+	}
+	drafts := []review.CommentDraft{{Path: "main.go", Line: 1, Side: review.SideRight, Body: "first note"}}
+	app := newUIDiffTestAppWithBaseDraftsAndStatus(rows, DefaultBaseColors(), false, drafts, true)
+	size := vui.Size{Width: 60, Height: 7}
+	app.Pump(size)
+	app.Pump(size)
+
+	app.Send(vaxis.Key{Text: " ", Keycode: vaxis.KeySpace})
+	app.Send(vaxis.Key{Text: "n", Keycode: 'n'})
+	app.Pump(size)
+	app.Send(vaxis.Key{Text: "j", Keycode: 'j'})
+	app.Send(vaxis.Key{Text: ":", Keycode: ':'})
+	app.Send(vaxis.Key{Text: "q"})
+	app.Send(vaxis.Key{Keycode: vaxis.KeyEnter})
+	app.Pump(size)
+	app.Send(vaxis.Key{Keycode: vaxis.KeyEsc})
+	app.Pump(size)
+
+	if app.ShouldQuit() {
+		t.Fatal("comment finder leaked :q to diff view")
+	}
+	p := vui.NewPainter(size)
+	app.Paint(p)
+	if got := uiDiffHighlightedScreenRow(p, uiDiffCursorRowBackground(uiDiffTestTheme())); got != 0 {
+		t.Fatalf("cursor row = %d, want unchanged row 0", got)
+	}
+}
+
 func TestUIDiffViewFileFinderStatsAreColorized(t *testing.T) {
 	theme := uiDiffTestTheme()
 	app := vui.NewApp(vui.Provider[vui.Theme]{Value: theme, Child: uiDiffFileStatWidget("+1 -1", theme)})

--- a/tui/ui_diff_viewer_test.go
+++ b/tui/ui_diff_viewer_test.go
@@ -624,6 +624,80 @@ func TestUIDiffViewCommentFinderJumpsToSelectedComment(t *testing.T) {
 	}
 }
 
+func TestUIDiffViewCommentFinderJumpsToSelectedCommentSideBySide(t *testing.T) {
+	rows := make([]diff.Row, 0, 20)
+	for line := 1; line <= 10; line++ {
+		rows = append(
+			rows,
+			diff.Row{Kind: diff.RowDelete, Gutter: fmt.Sprintf("%d     - ", line), Code: fmt.Sprintf("old %d", line), Review: review.Anchor{Path: "main.go", Line: line, Side: review.SideLeft}},
+			diff.Row{Kind: diff.RowAdd, Gutter: fmt.Sprintf("    %d + ", line), Code: fmt.Sprintf("new %d", line), Review: review.Anchor{Path: "main.go", Line: line, Side: review.SideRight}},
+		)
+	}
+	drafts := []review.CommentDraft{{Path: "main.go", Line: 2, Side: review.SideRight, Body: "selected note"}}
+	app := newUIDiffTestAppWithBaseDraftsAndStatus(rows, DefaultBaseColors(), false, drafts, true)
+	size := vui.Size{Width: 60, Height: 4}
+	app.Pump(size)
+	app.Pump(size)
+
+	app.Send(vaxis.Key{Text: "s", Keycode: 's'})
+	app.Pump(size)
+	app.Send(vaxis.Key{Text: " ", Keycode: vaxis.KeySpace})
+	app.Send(vaxis.Key{Text: "n", Keycode: 'n'})
+	app.Pump(size)
+	app.Send(vaxis.Key{Keycode: vaxis.KeyEnter})
+	app.Pump(size)
+	app.Pump(size)
+
+	p := vui.NewPainter(size)
+	app.Paint(p)
+	if _, _, ok := uiDiffFindText(p, "new 2"); !ok {
+		t.Fatal("selected side-by-side comment target row is not visible")
+	}
+}
+
+func TestUIDiffViewCommentFinderHandlesMouseSelection(t *testing.T) {
+	rows := []diff.Row{
+		{Kind: diff.RowAdd, Gutter: "1 1   ", Code: "first", Review: review.Anchor{Path: "main.go", Line: 1, Side: review.SideRight}},
+		{Kind: diff.RowAdd, Gutter: "2 2   ", Code: "second", Review: review.Anchor{Path: "main.go", Line: 2, Side: review.SideRight}},
+	}
+	drafts := []review.CommentDraft{
+		{Path: "main.go", Line: 1, Side: review.SideRight, Body: "first note"},
+		{Path: "main.go", Line: 2, Side: review.SideRight, Body: "second note"},
+	}
+	app := newUIDiffTestAppWithBaseDraftsAndStatus(rows, DefaultBaseColors(), false, drafts, true)
+	size := vui.Size{Width: 80, Height: 8}
+	app.Pump(size)
+	app.Pump(size)
+
+	app.Send(vaxis.Key{Text: " ", Keycode: vaxis.KeySpace})
+	app.Send(vaxis.Key{Text: "n", Keycode: 'n'})
+	app.Pump(size)
+	p := vui.NewPainter(size)
+	app.Paint(p)
+	col, row, ok := uiDiffFindText(p, "main.go:2")
+	if !ok {
+		t.Fatal("second comment finder item is not visible")
+	}
+
+	app.Send(vaxis.Mouse{Button: vaxis.MouseLeftButton, EventType: vaxis.EventPress, Row: row, Col: col})
+	app.Send(vaxis.Mouse{Button: vaxis.MouseLeftButton, EventType: vaxis.EventRelease, Row: row, Col: col})
+	app.Pump(size)
+	app.Pump(size)
+
+	p = vui.NewPainter(size)
+	app.Paint(p)
+	if _, _, ok := uiDiffFindText(p, "Find comment…"); ok {
+		t.Fatal("comment finder stayed visible after mouse selection")
+	}
+	col, row, ok = uiDiffFindText(p, "2 2   second")
+	if !ok {
+		t.Fatal("mouse-selected comment target row is not visible")
+	}
+	if got := p.Cell(col, row).Background; got != uiDiffCursorRowBackground(uiDiffTestTheme()) {
+		t.Fatalf("mouse-selected comment target background = %v, want cursor row background", got)
+	}
+}
+
 func TestUIDiffViewCommentFinderDoesNotOpenWithoutIndexedComments(t *testing.T) {
 	rows := []diff.Row{
 		{Kind: diff.RowAdd, Gutter: "1 1   ", Code: "first", Review: review.Anchor{Path: "main.go", Line: 1, Side: review.SideRight}},
@@ -713,6 +787,9 @@ func TestUIDiffViewQuestionTogglesHelpOverlay(t *testing.T) {
 	}
 	if _, _, ok := uiDiffFindText(p, "Open cursor location in editor"); !ok {
 		t.Fatal("help overlay did not include legacy keybinds")
+	}
+	if _, _, ok := uiDiffFindText(p, "Find comment"); !ok {
+		t.Fatal("help overlay did not include comment finder keybind")
 	}
 	if _, _, ok := uiDiffFindText(p, "╭"); ok {
 		t.Fatal("help overlay rendered border chrome")


### PR DESCRIPTION
## Summary

- add a searchable `<space>n` comment picker backed by the shared comment index
- show each indexed comment with target location and visible body preview
- jump to the selected comment's indexed target row

## Tests

- `mise exec -- go test ./tui -run 'CommentFinder' -count=1`
- `mise exec -- go test ./tui -run 'CommentFinder|FileFinder|BracketN|CommentIndex' -count=1`
- `mise run check`

Closes deevus/comview#3
